### PR TITLE
iOS: Temporarily disable KMP in prebuild

### DIFF
--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Build KMP"
-               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;scripts/build-kmp.sh&#10;">
+               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;#scripts/build-kmp.sh&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Build KMP"
-               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;scripts/build-kmp.sh&#10;">
+               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;#scripts/build-kmp.sh&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Build KMP"
-               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;scripts/build-kmp.sh&#10;">
+               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;#scripts/build-kmp.sh&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"


### PR DESCRIPTION
# :pencil: Description
- This PR temporarily disables the build of KMP in the Xcode pre-build steps

# :bulb: What’s new?
- Executing gradle from pre-build steps doesn't work with `xcodebuild` for some reason, therefore our CI builds are failing

# :no_mouth: What’s missing?
- For now it is disabled, we should move it to build phases and ensure that it will work with SPM as expected

# :books: References
- None
