### PR TITLE
iOS: Prefix release tag with ios

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -260,8 +260,8 @@ platform :ios do
   lane :tag do
     version = get_ipa_info_plist_value(ipa: "./ipa/#{production[:output_name]}.ipa", key: "CFBundleShortVersionString")
     build = get_ipa_info_plist_value(ipa: "./ipa/#{production[:output_name]}.ipa", key: "CFBundleVersion")
-    add_git_tag(tag: "#{version}.#{build}")
-    push_git_tags(tag: "#{version}.#{build}")
+    add_git_tag(tag: "ios/#{version}.#{build}")
+    push_git_tags(tag: "ios/#{version}.#{build}")
   end
 
   # You can define as many lanes as you want


### PR DESCRIPTION
# :pencil: Description
- Now that we have a monorepo we should distinguish between iOS / Android release tags by adding `ios/` and `android/` prefixes.

# :bulb: What’s new?
- This PR ensures that `ios/` prefix is added when tagging iOS releases

# :no_mouth: What’s missing?
- Nothing

# :books: References
- None
