### PR TITLE
iOS: Disable scripts when building for SwiftUI previews

### DIFF
--- a/ios/DevStack.xcodeproj/project.pbxproj
+++ b/ios/DevStack.xcodeproj/project.pbxproj
@@ -223,7 +223,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "scripts/swiftlint.sh\n";
+			shellScript = "if [ $ENABLE_PREVIEWS == \"NO\" ]\nthen\n    scripts/swiftlint.sh\nfi\n";
 		};
 		453D3FCD25ED976A0094ADD7 /* Copy GoogleService-Info.plist */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -255,7 +255,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${BUILD_DIR%Build/*}SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n";
+			shellScript = "if [ $ENABLE_PREVIEWS == \"NO\" ]\nthen\n    \"${BUILD_DIR%Build/*}SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Build KMP"
-               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;#scripts/build-kmp.sh&#10;">
+               scriptText = "if [ $ENABLE_PREVIEWS == &quot;NO&quot; ]&#10;then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;    #scripts/build-kmp.sh&#10;fi&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Generate resources and mocks"
-               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild.log 2&gt;&amp;1 # For debugging&#10;scripts/twine.sh&#10;scripts/swiftgen.sh&#10;scripts/swiftymocky.sh&#10;">
+               scriptText = "if [ $ENABLE_PREVIEWS == &quot;NO&quot; ]&#10;then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    exec &gt; prebuild.log 2&gt;&amp;1 # For debugging&#10;    scripts/twine.sh&#10;    scripts/swiftgen.sh&#10;    scripts/swiftymocky.sh&#10;fi&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Build KMP"
-               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;#scripts/build-kmp.sh&#10;">
+               scriptText = "if [ $ENABLE_PREVIEWS == &quot;NO&quot; ]&#10;then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;    #scripts/build-kmp.sh&#10;fi&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Generate resources and mocks"
-               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild.log 2&gt;&amp;1 # For debugging&#10;scripts/twine.sh&#10;scripts/swiftgen.sh&#10;scripts/swiftymocky.sh&#10;">
+               scriptText = "if [ $ENABLE_PREVIEWS == &quot;NO&quot; ]&#10;then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    exec &gt; prebuild.log 2&gt;&amp;1 # For debugging&#10;    scripts/twine.sh&#10;    scripts/swiftgen.sh&#10;    scripts/swiftymocky.sh&#10;fi&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Build KMP"
-               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;#scripts/build-kmp.sh&#10;">
+               scriptText = "if [ $ENABLE_PREVIEWS == &quot;NO&quot; ]&#10;then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;    #scripts/build-kmp.sh&#10;fi&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Generate resources and mocks"
-               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild.log 2&gt;&amp;1 # For debugging&#10;scripts/twine.sh&#10;scripts/swiftgen.sh&#10;scripts/swiftymocky.sh&#10;">
+               scriptText = "if [ $ENABLE_PREVIEWS == &quot;NO&quot; ]&#10;then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    exec &gt; prebuild.log 2&gt;&amp;1 # For debugging&#10;    scripts/twine.sh&#10;    scripts/swiftgen.sh&#10;    scripts/swiftymocky.sh&#10;fi&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"


### PR DESCRIPTION
# :pencil: Description
- This PR disables execution of build scripts when building for SwiftUI previews

# :bulb: What’s new?
- SwiftUI previews works as expected 🎉 

# :no_mouth: What’s missing?
- Nothing

# :books: References
- https://stackoverflow.com/a/62216533
- https://dev.to/vgorloff/swiftui-previews-in-modular-app-with-frameworks-1jp4
