### PR TITLE
iOS: Add FirebaseCrashlytics to DataLayer

### DIFF
--- a/ios/DataLayer/Package.swift
+++ b/ios/DataLayer/Package.swift
@@ -33,6 +33,7 @@ let package = Package(
             dependencies: [
                 .product(name: "DomainLayer", package: "DomainLayer"),
                 .product(name: "FirebaseAnalyticsWithoutAdIdSupport", package: "firebase-ios-sdk"),
+                .product(name: "FirebaseCrashlytics", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseMessaging", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseRemoteConfig", package: "firebase-ios-sdk"),
                 .product(name: "KeychainAccess", package: "KeychainAccess"),

--- a/ios/DevStack.xcodeproj/project.pbxproj
+++ b/ios/DevStack.xcodeproj/project.pbxproj
@@ -138,7 +138,6 @@
 				4558D30420FCC8FF005BC325 /* Frameworks */,
 				4558D30520FCC8FF005BC325 /* Resources */,
 				453D3FCD25ED976A0094ADD7 /* Copy GoogleService-Info.plist */,
-				4597628220FE17930034DE29 /* Run Firebase Crashlytics */,
 			);
 			buildRules = (
 			);
@@ -242,20 +241,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "GOOGLE_SERVICE_INFO_PLIST_FROM=\"${PROJECT_DIR}/${GOOGLE_SERVICE_INFO_PLIST_FILE}\"\nGOOGLE_SERVICE_INFO_PLIST_TO=\"${BUILT_PRODUCTS_DIR}/${FULL_PRODUCT_NAME}/GoogleService-Info.plist\"\ncp \"${GOOGLE_SERVICE_INFO_PLIST_FROM}\" \"${GOOGLE_SERVICE_INFO_PLIST_TO}\" \n";
-		};
-		4597628220FE17930034DE29 /* Run Firebase Crashlytics */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Firebase Crashlytics";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ $ENABLE_PREVIEWS == \"NO\" ]\nthen\n    \"${BUILD_DIR%Build/*}SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
# :pencil: Description
- This PR ensures that FirebaseCrashlytics works as expected

# :bulb: What’s new?
- When switching over to Swift Package Manager I forgot to add explicit FirebaseCrashlytics dependency to DataLayer, resulting in crashes not showing in the Firebase console 🤦‍♂️

# :no_mouth: What’s missing?
- Nothing

# :books: References
- https://firebase.google.com/docs/crashlytics/get-started
