### PR TITLE
iOS: LoginView tests

### DIFF
--- a/ios/PresentationLayer/Sources/PresentationLayer/App/Flow.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/App/Flow.swift
@@ -5,10 +5,9 @@
 
 import Foundation
 
-enum Flow {
+enum Flow: Equatable {
     case login(Login)
     case registration(Registration)
     case users(Users)
-    case books(Books)
     case profile(Profile)
 }

--- a/ios/PresentationLayer/Sources/PresentationLayer/App/Onboarding/Login-UIKit/LoginViewController.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/App/Onboarding/Login-UIKit/LoginViewController.swift
@@ -8,7 +8,7 @@ import RxSwift
 import UIKit
 
 extension Flow {
-    enum Login {
+    enum Login: Equatable {
         case dismiss
         case showRegistration
     }

--- a/ios/PresentationLayer/Sources/PresentationLayer/App/Onboarding/Registration/RegistrationViewController.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/App/Onboarding/Registration/RegistrationViewController.swift
@@ -7,7 +7,7 @@ import RxSwift
 import UIKit
 
 extension Flow {
-    enum Registration {
+    enum Registration: Equatable {
         case popRegistration
     }
 }

--- a/ios/PresentationLayer/Sources/PresentationLayer/App/Tab1-Users/Main/UsersViewController.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/App/Tab1-Users/Main/UsersViewController.swift
@@ -8,7 +8,7 @@ import RxSwift
 import UIKit
 
 extension Flow {
-    enum Users {
+    enum Users: Equatable {
         case showUserDetailForId(_ userId: String)
     }
 }

--- a/ios/PresentationLayer/Sources/PresentationLayer/App/Tab2-Profile/Main/Tab1-Profile/ProfileViewController.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/App/Tab2-Profile/Main/Tab1-Profile/ProfileViewController.swift
@@ -8,7 +8,7 @@ import RxSwift
 import UIKit
 
 extension Flow {
-    enum Profile {
+    enum Profile: Equatable {
         case presentOnboarding
     }
 }

--- a/ios/PresentationLayer/Sources/PresentationLayer/App/Tab4-Books/BooksFlowController.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/App/Tab4-Books/BooksFlowController.swift
@@ -11,16 +11,4 @@ class BooksFlowController: FlowController {
         let vm = BooksViewModel()
         return BooksViewController.instantiate(fc: self, vm: vm)
     }
-    
-    override func handleFlow(_ flow: Flow) {
-        switch flow {
-        case .books(let booksFlow): handleBooksFlow(booksFlow)
-        default: ()
-        }
-    }
-}
-
-// MARK: Books flow
-extension BooksFlowController {
-    func handleBooksFlow(_ flow: Flow.Books) {}
 }

--- a/ios/PresentationLayer/Sources/PresentationLayer/App/Tab4-Books/Main/BooksViewController.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/App/Tab4-Books/Main/BooksViewController.swift
@@ -7,10 +7,6 @@ import class DevstackKmpShared.Book
 import RxSwift
 import UIKit
 
-extension Flow {
-    enum Books {}
-}
-
 final class BooksViewController: BaseTableViewController<Book> {
     
     // MARK: FlowController

--- a/ios/PresentationLayer/Sources/PresentationLayer/Utilities/Alerts/AlertData.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/Utilities/Alerts/AlertData.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-struct AlertData: Identifiable {
+struct AlertData: Equatable, Identifiable {
     
     var id: String { title + (message ?? "") }
     

--- a/ios/PresentationLayer/Sources/PresentationLayer/Utilities/ViewModel.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/Utilities/ViewModel.swift
@@ -10,5 +10,6 @@ protocol ViewModel {
 
     var state: State { get }
     
-    func intent(_ intent: Intent)
+    @discardableResult
+    func intent(_ intent: Intent) -> Task<Void, Never>
 }

--- a/ios/PresentationLayer/Tests/PresentationLayerTests/FlowControllerMock.swift
+++ b/ios/PresentationLayer/Tests/PresentationLayerTests/FlowControllerMock.swift
@@ -1,0 +1,18 @@
+//
+//  Created by Petr Chmelar on 07.03.2022
+//  Copyright © 2022 Matee. All rights reserved.
+//
+
+import Foundation
+@testable import PresentationLayer
+
+class FlowControllerMock: FlowController {
+    
+    public var handleFlowCount = 0
+    public var handleFlowValue: Flow?
+    
+    override func handleFlow(_ flow: Flow) {
+        handleFlowCount += 1
+        handleFlowValue = flow
+    }
+}

--- a/ios/PresentationLayer/Tests/PresentationLayerTests/ViewModels/Onboarding/LoginViewModelTests.swift
+++ b/ios/PresentationLayer/Tests/PresentationLayerTests/ViewModels/Onboarding/LoginViewModelTests.swift
@@ -1,0 +1,99 @@
+//
+//  Created by Petr Chmelar on 07.03.2022
+//  Copyright © 2022 Matee. All rights reserved.
+//
+
+import DomainLayer
+import DomainStubs
+@testable import PresentationLayer
+import Resolver
+import SwiftyMocky
+import UseCaseMocks
+import XCTest
+
+class LoginViewModelTests: BaseTestCase {
+    
+    // MARK: Dependencies
+    
+    private let flowController = FlowControllerMock(navigationController: UINavigationController())
+    
+    private let loginUseCase = LoginUseCaseMock()
+    private let trackAnalyticsEventUseCase = TrackAnalyticsEventUseCaseMock()
+    
+    override func setupDependencies() {
+        super.setupDependencies()
+        
+        Resolver.register { self.loginUseCase as LoginUseCase }
+        Resolver.register { self.trackAnalyticsEventUseCase as TrackAnalyticsEventUseCase }
+        
+        Given(loginUseCase, .execute(
+            .value(.stubInvalidPassword),
+            willReturn: .error(RepositoryError(statusCode: StatusCode.httpUnathorized, message: ""))
+        ))
+        Given(loginUseCase, .execute(.any, willReturn: .just(())))
+    }
+
+    // MARK: Tests
+    
+    func testAppear() async {
+        let vm = LoginViewModel(flowController: flowController)
+        
+        await vm.intent(.onAppear).value
+        
+        Verify(trackAnalyticsEventUseCase, 1, .execute(.value(LoginEvent.screenAppear.analyticsEvent)))
+    }
+
+    func testLoginEmpty() async {
+        let vm = LoginViewModel(flowController: flowController)
+        
+        vm.intent(.onEmailChange(LoginData.stubEmpty.email))
+        vm.intent(.onPasswordChange(LoginData.stubEmpty.password))
+        await vm.intent(.onLoginButtonTap).value
+        
+        XCTAssert(!vm.state.loginButtonLoading)
+        XCTAssertEqual(vm.state.alert, AlertData(title: L10n.invalid_credentials))
+        XCTAssertEqual(flowController.handleFlowValue, nil)
+        Verify(loginUseCase, 0, .execute(.any))
+        Verify(trackAnalyticsEventUseCase, 0, .execute(.any))
+    }
+    
+    func testLoginValid() async {
+        let vm = LoginViewModel(flowController: flowController)
+        
+        vm.intent(.onEmailChange(LoginData.stubValid.email))
+        vm.intent(.onPasswordChange(LoginData.stubValid.password))
+        await vm.intent(.onLoginButtonTap).value
+        
+        XCTAssert(vm.state.loginButtonLoading)
+        XCTAssertEqual(vm.state.alert, nil)
+        XCTAssertEqual(flowController.handleFlowValue, .login(.dismiss))
+        Verify(loginUseCase, 1, .execute(.value(.stubValid)))
+        Verify(trackAnalyticsEventUseCase, 1, .execute(.value(LoginEvent.loginButtonTap.analyticsEvent)))
+    }
+    
+    func testLoginInvalidPassword() async {
+        let vm = LoginViewModel(flowController: flowController)
+        
+        vm.intent(.onEmailChange(LoginData.stubInvalidPassword.email))
+        vm.intent(.onPasswordChange(LoginData.stubInvalidPassword.password))
+        await vm.intent(.onLoginButtonTap).value
+        
+        XCTAssert(!vm.state.loginButtonLoading)
+        XCTAssertEqual(vm.state.alert, AlertData(title: L10n.invalid_credentials))
+        XCTAssertEqual(flowController.handleFlowValue, nil)
+        Verify(loginUseCase, 1, .execute(.value(.stubInvalidPassword)))
+        Verify(trackAnalyticsEventUseCase, 0, .execute(.any))
+    }
+
+    func testRegister() async {
+        let vm = LoginViewModel(flowController: flowController)
+        
+        await vm.intent(.onRegisterButtonTap).value
+        
+        XCTAssert(!vm.state.loginButtonLoading)
+        XCTAssertEqual(vm.state.alert, nil)
+        XCTAssertEqual(flowController.handleFlowValue, .login(.showRegistration))
+        Verify(loginUseCase, 0, .execute(.any))
+        Verify(trackAnalyticsEventUseCase, 1, .execute(.value(LoginEvent.registerButtonTap.analyticsEvent)))
+    }
+}


### PR DESCRIPTION
# :pencil: Description
- This PR adds missing tests for our new LoginView that is written in SwiftUI 🎉 

# :bulb: What’s new?
- Tests for the SwiftUI version of LoginView are available in `LoginViewModelTests`.
- Analogically to testing the ViewModel's **Output** based on a possible combination of ViewModel's **Inputs**, we are now testing the ViewModel's **State** based on a possible combination of ViewModel's **Intents**.
- The main difference is in the method of testing, in the RxSwift world we had to use the RxTest framework and check the content of output streams. That is no longer needed, we can simply use just `XCTAssert` and `XCTAssertEqual` to check the content of the ViewModel's state.
- The only challenge is with testing asynchronous code, we had this covered by using RxTest, but now we must somehow wait for the async function or Task in our tests. 🤔 Turns out, that the simplest solution is to modify `func intent(_ intent: Intent)` to return `Task`, so we can wait for the result in tests by using `await`.
- As we are now using FlowControllers directly in the ViewModels, we must provide a mock to test changes of the flow, so I added `FlowControllerMock` in order to do exactly that.

# :no_mouth: What’s missing?
- Builds are failing on the CI because we are still using Xcode 13.1.x there, therefore async-related stuff is limited to iOS 15. We can't update to 13.2.x because of [this issue](https://stackoverflow.com/questions/70373633/app-crashes-on-iphone-6-ios-12-5-while-testing-in-device-using-xcode-13-2). We can install both 13.1.x / 13.2.x and switch between them, but 13.3 with a fix for that issue should be available after today's Apple event.

# :books: References
- https://developer.apple.com/documentation/swift/task
- https://www.swiftbysundell.com/articles/the-role-tasks-play-in-swift-concurrency/
- https://www.swiftbysundell.com/articles/unit-testing-code-that-uses-async-await/
