### PR TITLE
iOS: Use async/await in LoginUseCase and AuthRepository

### DIFF
--- a/ios/DataLayer/Sources/DataLayer/Providers/Network/MoyaNetworkProvider.swift
+++ b/ios/DataLayer/Sources/DataLayer/Providers/Network/MoyaNetworkProvider.swift
@@ -107,4 +107,8 @@ extension MoyaNetworkProvider: NetworkProvider {
                 return .error(RepositoryError(statusCode: statusCode, message: response.description))
             }
     }
+    
+    public func request(_ endpoint: TargetType, withInterceptor: Bool) async throws -> Response {
+        return try await observableRequest(endpoint, withInterceptor: withInterceptor).asSingle().value
+    }
 }

--- a/ios/DataLayer/Sources/DataLayer/Providers/Network/NetworkProvider.swift
+++ b/ios/DataLayer/Sources/DataLayer/Providers/Network/NetworkProvider.swift
@@ -23,6 +23,16 @@ public protocol NetworkProvider {
     /// - returns: Observable which emits Response of a network call.
     ///
     func observableRequest(_ endpoint: TargetType, withInterceptor: Bool) -> Observable<Response>
+    
+    ///
+    /// Function for triggering a specified network call.
+    /// Automatically filters out API errors.
+    ///
+    /// - parameter endpoint: TargetType from Moya which specify API endpoint to be called.
+    /// - parameter withInterceptor: Optional parameter to specify whether build-in interceptor should be enabled.
+    /// - returns: Response of a network call.
+    ///
+    func request(_ endpoint: TargetType, withInterceptor: Bool) async throws -> Response
 }
 
 // This extension exists only to provide default values for parameters

--- a/ios/DataLayer/Sources/ProviderMocks/NetworkProviderMock.swift
+++ b/ios/DataLayer/Sources/ProviderMocks/NetworkProviderMock.swift
@@ -50,4 +50,8 @@ extension NetworkProviderMock: NetworkProvider {
             return stubbingProvider.rx.request(MultiTarget(endpoint)).asObservable().do { _ in self.observableRequestCallsCount += 1 }
         }
     }
+    
+    public func request(_ endpoint: TargetType, withInterceptor: Bool) async throws -> Response {
+        return try await observableRequest(endpoint, withInterceptor: withInterceptor).asSingle().value
+    }
 }

--- a/ios/DomainLayer/Sources/DomainLayer/Errors/RepositoryError.swift
+++ b/ios/DomainLayer/Sources/DomainLayer/Errors/RepositoryError.swift
@@ -11,7 +11,7 @@ public struct CommonError {
     public static let encoding = RepositoryError(statusCode: .networkError, message: "Object can't be encoded")
 }
 
-public struct RepositoryError: LocalizedError {
+public struct RepositoryError: LocalizedError, Equatable {
     
     public let statusCode: StatusCode
     private let message: String

--- a/ios/DomainLayer/Sources/DomainLayer/Repositories/AuthTokenRepository.swift
+++ b/ios/DomainLayer/Sources/DomainLayer/Repositories/AuthTokenRepository.swift
@@ -6,7 +6,8 @@
 import RxSwift
 
 public protocol AuthTokenRepository: AutoMockable {
-    func create(_ data: LoginData) -> Observable<AuthToken>
+    func create(_ data: LoginData) async throws -> AuthToken
+    func createRx(_ data: LoginData) -> Observable<AuthToken>
     func read() -> AuthToken?
     func delete()
 }

--- a/ios/DomainLayer/Sources/DomainLayer/UseCases/Auth/LoginUseCase.swift
+++ b/ios/DomainLayer/Sources/DomainLayer/UseCases/Auth/LoginUseCase.swift
@@ -6,7 +6,8 @@
 import RxSwift
 
 public protocol LoginUseCase: AutoMockable {
-    func execute(_ data: LoginData) -> Observable<Void>
+    func execute(_ data: LoginData) async throws
+    func executeRx(_ data: LoginData) -> Observable<Void>
 }
 
 public struct LoginUseCaseImpl: LoginUseCase {
@@ -17,7 +18,11 @@ public struct LoginUseCaseImpl: LoginUseCase {
         self.authTokenRepository = authTokenRepository
     }
     
-    public func execute(_ data: LoginData) -> Observable<Void> {
-        authTokenRepository.create(data).mapToVoid()
+    public func execute(_ data: LoginData) async throws {
+        _ = try await authTokenRepository.create(data)
+    }
+    
+    public func executeRx(_ data: LoginData) -> Observable<Void> {
+        authTokenRepository.createRx(data).mapToVoid()
     }
 }

--- a/ios/DomainLayer/Tests/DomainLayerTests/UseCases/Auth/LoginUseCaseTests.swift
+++ b/ios/DomainLayer/Tests/DomainLayerTests/UseCases/Auth/LoginUseCaseTests.swift
@@ -19,22 +19,31 @@ class LoginUseCaseTests: BaseTestCase {
     override func setupDependencies() {
         super.setupDependencies()
         
-        Given(authTokenRepository, .create(.any, willReturn: .just(AuthToken.stub)))
+        Given(authTokenRepository, .create(.any, willReturn: AuthToken.stub))
+        Given(authTokenRepository, .createRx(.any, willReturn: .just(AuthToken.stub)))
     }
     
     // MARK: Tests
+    
+    func testExecute() async throws {
+        let useCase = LoginUseCaseImpl(authTokenRepository: authTokenRepository)
+        
+        try await useCase.execute(.stubValid)
+        
+        Verify(authTokenRepository, 1, .create(.value(.stubValid)))
+    }
 
-    func testExecute() {
+    func testExecuteRx() {
         let useCase = LoginUseCaseImpl(authTokenRepository: authTokenRepository)
         let output = scheduler.createObserver(Bool.self)
         
-        useCase.execute(.stubValid).map { _ in true }.bind(to: output).disposed(by: disposeBag)
+        useCase.executeRx(.stubValid).map { _ in true }.bind(to: output).disposed(by: disposeBag)
         scheduler.start()
         
         XCTAssertEqual(output.events, [
             .next(0, true),
             .completed(0)
         ])
-        Verify(authTokenRepository, 1, .create(.value(.stubValid)))
+        Verify(authTokenRepository, 1, .createRx(.value(.stubValid)))
     }
 }

--- a/ios/Mintfile
+++ b/ios/Mintfile
@@ -1,4 +1,4 @@
-SwiftGen/SwiftGen@6.5.0
-realm/SwiftLint@0.42.0
-MakeAWishFoundation/SwiftyMocky-CLI@4.0.3
-krzysztofzablocki/Sourcery@1.0.2
+SwiftGen/SwiftGen@6.5.1
+realm/SwiftLint@0.46.5
+MakeAWishFoundation/SwiftyMocky@4.1.0
+krzysztofzablocki/Sourcery@1.6.0

--- a/ios/PresentationLayer/Sources/PresentationLayer/App/Onboarding/Login-UIKit/LoginViewModelUIKit.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/App/Onboarding/Login-UIKit/LoginViewModelUIKit.swift
@@ -64,7 +64,7 @@ final class LoginViewModelUIKit: BaseViewModel, ViewModelUIKit {
             } else {
                 trackAnalyticsEventUseCase.execute(LoginEvent.loginButtonTap.analyticsEvent)
                 let data = LoginData(email: inputs.email, password: inputs.password)
-                return loginUseCase.execute(data).trackActivity(activity).materialize()
+                return loginUseCase.executeRx(data).trackActivity(activity).materialize()
             }
         }.share()
         

--- a/ios/PresentationLayer/Sources/PresentationLayer/App/Onboarding/Login/LoginViewModel.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/App/Onboarding/Login/LoginViewModel.swift
@@ -89,7 +89,7 @@ final class LoginViewModel: BaseViewModel, ViewModel, ObservableObject {
         do {
             state.loginButtonLoading = true
             let data = LoginData(email: state.email, password: state.password)
-            try await loginUseCase.execute(data).asSingle().value
+            try await loginUseCase.execute(data)
             trackAnalyticsEventUseCase.execute(LoginEvent.loginButtonTap.analyticsEvent)
             flowController?.handleFlow(.login(.dismiss))
         } catch {

--- a/ios/PresentationLayer/Sources/PresentationLayer/PreviewMocks/UseCasePreviewMocks.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/PreviewMocks/UseCasePreviewMocks.swift
@@ -8,7 +8,8 @@ import Foundation
 import RxSwift
 
 class LoginUseCasePreviewMock: LoginUseCase {
-    func execute(_ data: LoginData) -> Observable<Void> { .just(()) }
+    func execute(_ data: LoginData) async throws {}
+    func executeRx(_ data: LoginData) -> Observable<Void> { .just(()) }
 }
 
 class TrackAnalyticsEventUseCasePreviewMock: TrackAnalyticsEventUseCase {

--- a/ios/PresentationLayer/Tests/PresentationLayerTests/ViewModels/Onboarding/LoginViewModelTests.swift
+++ b/ios/PresentationLayer/Tests/PresentationLayerTests/ViewModels/Onboarding/LoginViewModelTests.swift
@@ -28,9 +28,8 @@ class LoginViewModelTests: BaseTestCase {
         
         Given(loginUseCase, .execute(
             .value(.stubInvalidPassword),
-            willReturn: .error(RepositoryError(statusCode: StatusCode.httpUnathorized, message: ""))
+            willThrow: RepositoryError(statusCode: StatusCode.httpUnathorized, message: "")
         ))
-        Given(loginUseCase, .execute(.any, willReturn: .just(())))
     }
 
     // MARK: Tests

--- a/ios/PresentationLayer/Tests/PresentationLayerTests/ViewModels/Onboarding/LoginViewModelUIKitTests.swift
+++ b/ios/PresentationLayer/Tests/PresentationLayerTests/ViewModels/Onboarding/LoginViewModelUIKitTests.swift
@@ -22,11 +22,11 @@ class LoginViewModelUIKitTests: BaseTestCase {
     override func setupDependencies() {
         super.setupDependencies()
         
-        Given(loginUseCase, .execute(
+        Given(loginUseCase, .executeRx(
             .value(.stubInvalidPassword),
             willReturn: .error(RepositoryError(statusCode: StatusCode.httpUnathorized, message: ""))
         ))
-        Given(loginUseCase, .execute(.any, willReturn: .just(())))
+        Given(loginUseCase, .executeRx(.any, willReturn: .just(())))
     }
 
     // MARK: Inputs and outputs
@@ -111,7 +111,7 @@ class LoginViewModelUIKitTests: BaseTestCase {
             .next(0, false),
             .next(0, true)
         ])
-        Verify(loginUseCase, 1, .execute(.value(.stubValid)))
+        Verify(loginUseCase, 1, .executeRx(.value(.stubValid)))
         Verify(trackAnalyticsEventUseCase, 1, .execute(.value(LoginEvent.loginButtonTap.analyticsEvent)))
     }
 
@@ -130,7 +130,7 @@ class LoginViewModelUIKitTests: BaseTestCase {
             .next(0, false),
             .next(0, true)
         ])
-        Verify(loginUseCase, 1, .execute(.value(.stubInvalidPassword)))
+        Verify(loginUseCase, 1, .executeRx(.value(.stubInvalidPassword)))
     }
     
     func testLoginInvalidThenValid() {
@@ -154,8 +154,8 @@ class LoginViewModelUIKitTests: BaseTestCase {
             .next(10, false),
             .next(10, true)
         ])
-        Verify(loginUseCase, 1, .execute(.value(.stubInvalidPassword)))
-        Verify(loginUseCase, 1, .execute(.value(.stubValid)))
+        Verify(loginUseCase, 1, .executeRx(.value(.stubInvalidPassword)))
+        Verify(loginUseCase, 1, .executeRx(.value(.stubValid)))
     }
 
     func testRegister() {
@@ -170,7 +170,7 @@ class LoginViewModelUIKitTests: BaseTestCase {
         XCTAssertEqual(output.loginButtonEnabled.events, [
             .next(0, true)
         ])
-        Verify(loginUseCase, 0, .execute(.any))
+        Verify(loginUseCase, 0, .executeRx(.any))
         Verify(trackAnalyticsEventUseCase, 1, .execute(.value(LoginEvent.registerButtonTap.analyticsEvent)))
     }
 }


### PR DESCRIPTION
# :pencil: Description
- This PR adds an example of async/await usage in UseCase and Repository 🚀 

# :bulb: What’s new?
- `LoginUseCase.execute()` is now using async/await, older RxSwift implementation renamed to `.executeRx()`
- `AuthRepository.create()` is now using async/await, older RxSwift implementation renamed to `.createRx()`
- `NetworkProvider` now has `.request()` with async/await, it is just a wrapper around `.observableRequest()` that is using RxSwift internally. We would later add a proper full async/await implementation, probably together with migration from Moya to NSURLSession.
- Tools updated - SwiftyMocky 4.1.0 was needed for proper mocking of async functions

# :no_mouth: What’s missing?
- Nothing

# :books: References
- https://www.avanderlee.com/swift/async-await
- https://mokacoding.com/blog/how-to-test-async-await-code-in-swift/
- https://github.com/MakeAWishFoundation/SwiftyMocky/issues/290