### PR TITLE
iOS: BaseViewModel with proper task management

### DIFF
--- a/ios/PresentationLayer/Sources/PresentationLayer/App/Onboarding/Login/LoginView.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/App/Onboarding/Login/LoginView.swift
@@ -19,23 +19,21 @@ struct LoginView: View {
             LoginViewFields(
                 email: viewModel.state.email,
                 password: viewModel.state.password,
-                onEmailChange: { email in viewModel.intent(.onEmailChange(email)) },
-                onPasswordChange: { password in viewModel.intent(.onPasswordChange(password)) }
+                onEmailChange: { email in viewModel.onIntent(.changeEmail(email)) },
+                onPasswordChange: { password in viewModel.onIntent(.changePassword(password)) }
             )
             Spacer()
             LoginViewButtons(
                 loginButtonLoading: viewModel.state.loginButtonLoading,
-                onLoginButtonTap: { viewModel.intent(.onLoginButtonTap) },
-                onRegisterButtonTap: { viewModel.intent(.onRegisterButtonTap) }
+                onLoginButtonTap: { viewModel.onIntent(.login) },
+                onRegisterButtonTap: { viewModel.onIntent(.register) }
             )
         }
         .alert(item: Binding<AlertData?>(
             get: { viewModel.state.alert },
-            set: { _ in viewModel.intent(.onAlertDismiss) }
+            set: { _ in viewModel.onIntent(.dismissAlert) }
         )) { alert in .init(alert) }
-        .onAppear {
-            viewModel.intent(.onAppear)
-        }
+        .lifecycle(viewModel)
     }
 }
 

--- a/ios/PresentationLayer/Sources/PresentationLayer/Extensions/View+Extensions.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/Extensions/View+Extensions.swift
@@ -1,0 +1,19 @@
+//
+//  Created by Petr Chmelar on 12.03.2022
+//  Copyright © 2022 Matee. All rights reserved.
+//
+
+import SwiftUI
+
+@MainActor
+public extension View {
+    @inlinable func lifecycle(_ viewModel: BaseViewModel) -> some View {
+        self
+            .onAppear {
+                viewModel.onAppear()
+            }
+            .onDisappear {
+                viewModel.onDisappear()
+            }
+    }
+}

--- a/ios/PresentationLayer/Sources/PresentationLayer/Utilities/BaseViewModel.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/Utilities/BaseViewModel.swift
@@ -4,6 +4,7 @@
 //
 
 import DomainLayer
+import Foundation
 
 @MainActor
 public class BaseViewModel {
@@ -35,7 +36,11 @@ public class BaseViewModel {
         tasks.append(task)
         return Task {
             await task.value
-            tasks = tasks.filter { $0 != task } // Remove task when done
+            
+            // Remove task when done
+            objc_sync_enter(tasks)
+            tasks = tasks.filter { $0 != task }
+            objc_sync_exit(tasks)
         }
     }
 }

--- a/ios/PresentationLayer/Sources/PresentationLayer/Utilities/ViewModel.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/Utilities/ViewModel.swift
@@ -5,11 +5,15 @@
 
 @MainActor
 protocol ViewModel {
+    // Lifecycle
+    func onAppear()
+    func onDisappear()
+    
+    // State
     associatedtype State
-    associatedtype Intent
-
     var state: State { get }
     
-    @discardableResult
-    func intent(_ intent: Intent) -> Task<Void, Never>
+    // Intent
+    associatedtype Intent
+    @discardableResult func onIntent(_ intent: Intent) -> Task<Void, Never>
 }

--- a/ios/PresentationLayer/Tests/PresentationLayerTests/ViewModels/Onboarding/LoginViewModelTests.swift
+++ b/ios/PresentationLayer/Tests/PresentationLayerTests/ViewModels/Onboarding/LoginViewModelTests.swift
@@ -37,7 +37,7 @@ class LoginViewModelTests: BaseTestCase {
     func testAppear() async {
         let vm = LoginViewModel(flowController: flowController)
         
-        await vm.intent(.onAppear).value
+        vm.onAppear()
         
         Verify(trackAnalyticsEventUseCase, 1, .execute(.value(LoginEvent.screenAppear.analyticsEvent)))
     }
@@ -45,9 +45,9 @@ class LoginViewModelTests: BaseTestCase {
     func testLoginEmpty() async {
         let vm = LoginViewModel(flowController: flowController)
         
-        vm.intent(.onEmailChange(LoginData.stubEmpty.email))
-        vm.intent(.onPasswordChange(LoginData.stubEmpty.password))
-        await vm.intent(.onLoginButtonTap).value
+        vm.onIntent(.changeEmail(LoginData.stubEmpty.email))
+        vm.onIntent(.changePassword(LoginData.stubEmpty.password))
+        await vm.onIntent(.login).value
         
         XCTAssert(!vm.state.loginButtonLoading)
         XCTAssertEqual(vm.state.alert, AlertData(title: L10n.invalid_credentials))
@@ -59,9 +59,9 @@ class LoginViewModelTests: BaseTestCase {
     func testLoginValid() async {
         let vm = LoginViewModel(flowController: flowController)
         
-        vm.intent(.onEmailChange(LoginData.stubValid.email))
-        vm.intent(.onPasswordChange(LoginData.stubValid.password))
-        await vm.intent(.onLoginButtonTap).value
+        vm.onIntent(.changeEmail(LoginData.stubValid.email))
+        vm.onIntent(.changePassword(LoginData.stubValid.password))
+        await vm.onIntent(.login).value
         
         XCTAssert(vm.state.loginButtonLoading)
         XCTAssertEqual(vm.state.alert, nil)
@@ -73,9 +73,9 @@ class LoginViewModelTests: BaseTestCase {
     func testLoginInvalidPassword() async {
         let vm = LoginViewModel(flowController: flowController)
         
-        vm.intent(.onEmailChange(LoginData.stubInvalidPassword.email))
-        vm.intent(.onPasswordChange(LoginData.stubInvalidPassword.password))
-        await vm.intent(.onLoginButtonTap).value
+        vm.onIntent(.changeEmail(LoginData.stubInvalidPassword.email))
+        vm.onIntent(.changePassword(LoginData.stubInvalidPassword.password))
+        await vm.onIntent(.login).value
         
         XCTAssert(!vm.state.loginButtonLoading)
         XCTAssertEqual(vm.state.alert, AlertData(title: L10n.invalid_credentials))
@@ -87,7 +87,7 @@ class LoginViewModelTests: BaseTestCase {
     func testRegister() async {
         let vm = LoginViewModel(flowController: flowController)
         
-        await vm.intent(.onRegisterButtonTap).value
+        await vm.onIntent(.register).value
         
         XCTAssert(!vm.state.loginButtonLoading)
         XCTAssertEqual(vm.state.alert, nil)


### PR DESCRIPTION
# :pencil: Description
- This PR adds a proper task management into the BaseViewModel 🤓 

# :bulb: What’s new?
- `Task` is executing even if we didn’t keep a reference to it, therefore it is not cancelled automatically when a view disappears (see references for more info). Modifier `.task()` in SwiftUI ensures that a task will automatically be canceled when the view disappears, but there is nothing yet to ensure this for button actions etc.
- You may say that it's not a big deal, as every Task will eventually ends and release all of its retained resources. Well yes, but it may cause various side-effects. For example, a user can tap on Login button and then immediately go to Registration. So he is on the Registration view when Login request ends and the whole Onboarding modal is dismissed, resulting in confusing behaviour.
- If we want to make sure that every task is cancelled when a view disappears, we must keep a reference to every active task and call `.cancel()` in `.onDisappear { ... }`. Because this is something we will likely want to do for every Task, I abstracted most of the logic into `BaseViewModel`. So now it is just a matter of calling `executeTask(Task{ ... })` and connecting the View with its ViewModel via `.lifecycle(viewModel)`.

# :no_mouth: What’s missing?
- Nothing

# :books: References
- https://www.avanderlee.com/concurrency/tasks/
- https://www.hackingwithswift.com/quick-start/concurrency/how-to-cancel-a-task
- https://forums.swift.org/t/what-happens-if-a-task-is-not-canceled/55299
- https://www.swiftbysundell.com/articles/memory-management-when-using-async-await/
