### PR TITLE
iOS: Update Realm

### DIFF
--- a/ios/DevStack.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/DevStack.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -204,8 +204,8 @@
         "repositoryURL": "https://github.com/realm/realm-cocoa.git",
         "state": {
           "branch": null,
-          "revision": "9dff9f2862240d521ad6ad599541269177ddb993",
-          "version": "10.22.0"
+          "revision": "11ef7d31e3f3668c7434c5fd129a85ca52740b24",
+          "version": "10.24.1"
         }
       },
       {
@@ -213,8 +213,17 @@
         "repositoryURL": "https://github.com/realm/realm-core",
         "state": {
           "branch": null,
-          "revision": "6b81f1a7a2d421f9e0b9e7f04e76bcf736a54409",
-          "version": "11.9.0"
+          "revision": "e9eec444d13ebebc062202407e79b9833428a24e",
+          "version": "11.11.0"
+        }
+      },
+      {
+        "package": "Resolver",
+        "repositoryURL": "https://github.com/hmlongco/Resolver",
+        "state": {
+          "branch": null,
+          "revision": "97de0b0320036607564af4a60025b48f8d041221",
+          "version": "1.5.0"
         }
       },
       {

--- a/ios/PresentationLayer/Sources/PresentationLayer/App/Main/MainFlowController.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/App/Main/MainFlowController.swift
@@ -6,7 +6,6 @@
 import DomainLayer
 import UIKit
 
-@MainActor
 protocol MainFlowControllerDelegate: AnyObject {
     func presentOnboarding(animated: Bool, completion: (() -> Void)?)
 }

--- a/ios/PresentationLayer/Sources/PresentationLayer/App/Onboarding/OnboardingFlowController.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/App/Onboarding/OnboardingFlowController.swift
@@ -6,7 +6,6 @@
 import SwiftUI
 import UIKit
 
-@MainActor
 protocol OnboardingFlowControllerDelegate: AnyObject {
     func setupMain()
 }

--- a/ios/PresentationLayer/Sources/PresentationLayer/App/Tab2-Profile/ProfileFlowController.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/App/Tab2-Profile/ProfileFlowController.swift
@@ -5,7 +5,6 @@
 
 import UIKit
 
-@MainActor
 protocol ProfileFlowControllerDelegate: AnyObject {
     func presentOnboarding()
 }


### PR DESCRIPTION
# :pencil: Description
- This PR updates Realm in order to compile the app under Xcode 13.3

# :bulb: What’s new?
- App can be compiled under Xcode 13.3
- As @DavidKadlcek found out, in Xcode 13.3 we don't have to use `@MainActor` in delegates 

# :no_mouth: What’s missing?
- Nothing

# :books: References
- https://github.com/realm/realm-swift/releases
