### PR TITLE
Fix SwiftyMocky for Xcode 13.3

### DIFF
--- a/ios/Mintfile
+++ b/ios/Mintfile
@@ -1,4 +1,4 @@
 SwiftGen/SwiftGen@6.5.1
 realm/SwiftLint@0.46.5
 MakeAWishFoundation/SwiftyMocky@4.1.0
-krzysztofzablocki/Sourcery@1.6.0
+krzysztofzablocki/Sourcery@1.8.0

--- a/ios/Mockfile
+++ b/ios/Mockfile
@@ -1,4 +1,4 @@
-sourceryCommand: null
+sourceryCommand: mint run sourcery
 sourceryTemplate: null
 
 UseCases:


### PR DESCRIPTION
# :pencil: Description
- This PR fixes SwiftyMocky in Xcode 13.3

# :bulb: What’s new?
- Sourcery 1.8.0 specified manually (older versions don't work with Xcode 13.3)

# :no_mouth: What’s missing?
- Update SwiftyMocky when a new version is out (to avoid manually specifying sourcery command in Mockfile)

# :books: References
- https://github.com/MakeAWishFoundation/SwiftyMocky/issues/306
