### PR TITLE
Make codebase more CRUD-like

### DIFF
--- a/ios/DataLayer/Sources/DataLayer/NetworkEndpoints/UserAPI.swift
+++ b/ios/DataLayer/Sources/DataLayer/NetworkEndpoints/UserAPI.swift
@@ -7,8 +7,8 @@ import DomainLayer
 import Foundation
 
 enum UserAPI {
-    case getUsersForPage(_ page: Int)
-    case getUserById(_ id: String)
+    case readUsersForPage(_ page: Int)
+    case readUserById(_ id: String)
     case updateUserById(_ id: String, data: [String: Any])
 }
 
@@ -16,11 +16,11 @@ extension UserAPI: NetworkEndpoint {
     var baseURL: URL { URL(string: "\(NetworkingConstants.baseURL)/api")! }
     var path: String {
         switch self {
-        case .getUsersForPage:
+        case .readUsersForPage:
             return "/user"
-        case .getUserById(let id):
+        case let .readUserById(id):
             return "/user/\(id)"
-        case .updateUserById(let id, _):
+        case let .updateUserById(id, _):
             return "/user/\(id)"
         }
     }
@@ -37,13 +37,13 @@ extension UserAPI: NetworkEndpoint {
     }
     var task: NetworkTask {
         switch self {
-        case .getUsersForPage(let page):
+        case let .readUsersForPage(page):
             let params: [String: Any] = [
                 "page": page,
                 "limit": Constants.paginationCount
             ]
             return .requestParameters(parameters: params, encoding: URLEncoding.default)
-        case .updateUserById(_, let data):
+        case let .updateUserById(_, data):
             return .requestParameters(parameters: data, encoding: JSONEncoding.default)
         default:
             return .requestPlain
@@ -51,9 +51,9 @@ extension UserAPI: NetworkEndpoint {
     }
     var sampleData: Data {
         switch self {
-        case .getUsersForPage:
+        case .readUsersForPage:
             return NETUser.stubList
-        case .getUserById, .updateUserById:
+        case .readUserById, .updateUserById:
             return NETUser.stub
         }
     }

--- a/ios/DataLayer/Sources/DataLayer/Providers/Keychain/KeychainProvider.swift
+++ b/ios/DataLayer/Sources/DataLayer/Providers/Keychain/KeychainProvider.swift
@@ -11,12 +11,12 @@ public enum KeychainCoding: String, CaseIterable {
 }
 
 public protocol KeychainProvider: AutoMockable {
+    
+    /// Try to read a value for the given key
+    func read(_ key: KeychainCoding) -> String?
 
-    /// Save the given key/value combination
-    func save(_ key: KeychainCoding, value: String)
-
-    /// Try to retrieve a value for the given key
-    func get(_ key: KeychainCoding) -> String?
+    /// Create or update the given key with a given value
+    func update(_ key: KeychainCoding, value: String)
 
     /// Delete value for the given key
     func delete(_ key: KeychainCoding)

--- a/ios/DataLayer/Sources/DataLayer/Providers/Keychain/SystemKeychainProvider.swift
+++ b/ios/DataLayer/Sources/DataLayer/Providers/Keychain/SystemKeychainProvider.swift
@@ -12,26 +12,26 @@ public struct SystemKeychainProvider {
     
     public init(userDefaultsProvider: UserDefaultsProvider) {
         // Clear keychain on first run
-        if (userDefaultsProvider.get(.hasRunBefore) as Bool?) == nil {
+        if (userDefaultsProvider.read(.hasRunBefore) as Bool?) == nil {
             deleteAll()
-            userDefaultsProvider.save(.hasRunBefore, value: true)
+            userDefaultsProvider.update(.hasRunBefore, value: true)
         }
     }
 }
 
 extension SystemKeychainProvider: KeychainProvider {
     
-    public func save(_ key: KeychainCoding, value: String) {
-        guard let bundleId = Bundle.app.bundleIdentifier else { return }
-        let keychain = Keychain(service: bundleId, accessGroup: "group.\(bundleId)")
-        keychain[key.rawValue] = value
-    }
-    
-    public func get(_ key: KeychainCoding) -> String? {
+    public func read(_ key: KeychainCoding) -> String? {
         guard let bundleId = Bundle.app.bundleIdentifier else { return nil }
         let keychain = Keychain(service: bundleId, accessGroup: "group.\(bundleId)")
         guard let value = keychain[key.rawValue] else { return nil }
         return value
+    }
+    
+    public func update(_ key: KeychainCoding, value: String) {
+        guard let bundleId = Bundle.app.bundleIdentifier else { return }
+        let keychain = Keychain(service: bundleId, accessGroup: "group.\(bundleId)")
+        keychain[key.rawValue] = value
     }
     
     public func delete(_ key: KeychainCoding) {

--- a/ios/DataLayer/Sources/DataLayer/Providers/Network/NetworkProvider.swift
+++ b/ios/DataLayer/Sources/DataLayer/Providers/Network/NetworkProvider.swift
@@ -22,6 +22,7 @@ public protocol NetworkProvider {
     /// - parameter withInterceptor: Optional parameter to specify whether build-in interceptor should be enabled.
     /// - returns: Data from a network call.
     ///
+    @discardableResult
     func request(_ endpoint: NetworkEndpoint, withInterceptor: Bool) async throws -> Data
 
     ///
@@ -37,6 +38,7 @@ public protocol NetworkProvider {
 
 // This extension exists only to provide default values for parameters
 extension NetworkProvider {
+    @discardableResult
     func request(_ endpoint: NetworkEndpoint, withInterceptor: Bool = true) async throws -> Data {
         try await request(endpoint, withInterceptor: withInterceptor)
     }

--- a/ios/DataLayer/Sources/DataLayer/Providers/Network/SystemNetworkProvider.swift
+++ b/ios/DataLayer/Sources/DataLayer/Providers/Network/SystemNetworkProvider.swift
@@ -53,7 +53,7 @@ extension SystemNetworkProvider: NetworkProvider {
         if let headers = endpoint.headers {
             headers.forEach { request.addValue($0.value, forHTTPHeaderField: $0.key) }
         }
-        if let authToken = keychainProvider.get(.authToken) {
+        if let authToken = keychainProvider.read(.authToken) {
             request.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
         }
         

--- a/ios/DataLayer/Sources/DataLayer/Providers/RemoteConfig/FirebaseRemoteConfigProvider.swift
+++ b/ios/DataLayer/Sources/DataLayer/Providers/RemoteConfig/FirebaseRemoteConfigProvider.swift
@@ -27,7 +27,7 @@ public struct FirebaseRemoteConfigProvider {
 
 extension FirebaseRemoteConfigProvider: RemoteConfigProvider {
     
-    public func get(_ key: RemoteConfigCoding) -> Observable<Bool> {
+    public func read(_ key: RemoteConfigCoding) -> Observable<Bool> {
         return RemoteConfig.remoteConfig().rx.fetch().flatMap { _ -> Observable<Bool> in
             let boolValue = RemoteConfig.remoteConfig().configValue(forKey: key.rawValue).boolValue
             return Observable.just(boolValue)

--- a/ios/DataLayer/Sources/DataLayer/Providers/RemoteConfig/RemoteConfigProvider.swift
+++ b/ios/DataLayer/Sources/DataLayer/Providers/RemoteConfig/RemoteConfigProvider.swift
@@ -7,6 +7,6 @@ import DomainLayer
 import RxSwift
 
 public protocol RemoteConfigProvider: AutoMockable {
-    /// Try to retrieve a value for the given key
-    func get(_ key: RemoteConfigCoding) -> Observable<Bool>
+    /// Try to read a value for the given key
+    func read(_ key: RemoteConfigCoding) -> Observable<Bool>
 }

--- a/ios/DataLayer/Sources/DataLayer/Providers/UserDefaults/SystemUserDefaultsProvider.swift
+++ b/ios/DataLayer/Sources/DataLayer/Providers/UserDefaults/SystemUserDefaultsProvider.swift
@@ -12,14 +12,14 @@ public struct SystemUserDefaultsProvider {
 
 extension SystemUserDefaultsProvider: UserDefaultsProvider {
     
-    public func save<T>(_ key: UserDefaultsCoding, value: T) {
-        guard let bundleId = Bundle.app.bundleIdentifier, let defaults = UserDefaults(suiteName: "group.\(bundleId)") else { return }
-        defaults.set(value, forKey: key.rawValue)
-    }
-    
-    public func get<T>(_ key: UserDefaultsCoding) -> T? {
+    public func read<T>(_ key: UserDefaultsCoding) -> T? {
         guard let bundleId = Bundle.app.bundleIdentifier, let defaults = UserDefaults(suiteName: "group.\(bundleId)") else { return nil }
         return defaults.object(forKey: key.rawValue) as? T
+    }
+    
+    public func update<T>(_ key: UserDefaultsCoding, value: T) {
+        guard let bundleId = Bundle.app.bundleIdentifier, let defaults = UserDefaults(suiteName: "group.\(bundleId)") else { return }
+        defaults.set(value, forKey: key.rawValue)
     }
     
     public func delete(_ key: UserDefaultsCoding) {

--- a/ios/DataLayer/Sources/DataLayer/Providers/UserDefaults/UserDefaultsProvider.swift
+++ b/ios/DataLayer/Sources/DataLayer/Providers/UserDefaults/UserDefaultsProvider.swift
@@ -10,12 +10,12 @@ public enum UserDefaultsCoding: String, CaseIterable {
 }
 
 public protocol UserDefaultsProvider: AutoMockable {
+    
+    /// Try to read a value for the given key
+    func read<T>(_ key: UserDefaultsCoding) -> T?
 
-    /// Save the given key/value combination
-    func save<T>(_ key: UserDefaultsCoding, value: T)
-
-    /// Try to retrieve a value for the given key
-    func get<T>(_ key: UserDefaultsCoding) -> T?
+    /// Create or update the given key with a given value
+    func update<T>(_ key: UserDefaultsCoding, value: T)
 
     /// Delete value for the given key
     func delete(_ key: UserDefaultsCoding)

--- a/ios/DataLayer/Sources/DataLayer/Repositories/AuthTokenRepository.swift
+++ b/ios/DataLayer/Sources/DataLayer/Repositories/AuthTokenRepository.swift
@@ -25,8 +25,8 @@ public struct AuthTokenRepositoryImpl: AuthTokenRepository {
     public func create(_ data: LoginData) async throws -> AuthToken {
         guard let data = data.networkModel.encoded else { throw CommonError.encoding }
         let authToken = try await network.request(AuthAPI.login(data), withInterceptor: false).map(NETAuthToken.self).domainModel
-        keychain.save(.authToken, value: authToken.token)
-        keychain.save(.userId, value: authToken.userId)
+        keychain.update(.authToken, value: authToken.token)
+        keychain.update(.userId, value: authToken.userId)
         return authToken
     }
     
@@ -34,13 +34,13 @@ public struct AuthTokenRepositoryImpl: AuthTokenRepository {
         guard let data = data.networkModel.encoded else { return .error(CommonError.encoding) }
         let endpoint = AuthAPI.login(data)
         return network.observableRequest(endpoint, withInterceptor: false).map(NETAuthToken.self).mapToDomain().do { authToken in
-            self.keychain.save(.authToken, value: authToken.token)
-            self.keychain.save(.userId, value: authToken.userId)
+            self.keychain.update(.authToken, value: authToken.token)
+            self.keychain.update(.userId, value: authToken.userId)
         }
     }
     
     public func read() -> AuthToken? {
-        guard let userId = keychain.get(.userId), let token = keychain.get(.authToken) else { return nil }
+        guard let userId = keychain.read(.userId), let token = keychain.read(.authToken) else { return nil }
         return AuthToken(userId: userId, token: token)
     }
     

--- a/ios/DataLayer/Sources/DataLayer/Repositories/RemoteConfigRepository.swift
+++ b/ios/DataLayer/Sources/DataLayer/Repositories/RemoteConfigRepository.swift
@@ -15,6 +15,6 @@ public struct RemoteConfigRepositoryImpl: RemoteConfigRepository {
     }
     
     public func read(_ key: RemoteConfigCoding) -> Observable<Bool> {
-        remoteConfig.get(key)
+        remoteConfig.read(key)
     }
 }

--- a/ios/DataLayer/Sources/DataLayer/Repositories/UserRepository.swift
+++ b/ios/DataLayer/Sources/DataLayer/Repositories/UserRepository.swift
@@ -27,14 +27,14 @@ public struct UserRepositoryImpl: UserRepository {
     
     public func read(_ sourceType: SourceType, id: String) -> Observable<User> {
         let db = database.observableObject(DBUser.self, id: id)
-        let endpoint = UserAPI.getUserById(id)
+        let endpoint = UserAPI.readUserById(id)
         let net = network.observableRequest(endpoint).map(NETUser.self).mapToDatabase().save(to: database)
         return sourceType.result(db: db.mapToDomain(), net: net.mapToDomain())
     }
     
-    public func list(_ sourceType: SourceType, page: Int, sortBy: String?) -> Observable<[User]> {
+    public func read(_ sourceType: SourceType, page: Int, sortBy: String?) -> Observable<[User]> {
         let db = database.observableCollection(DBUser.self, sortBy: sortBy)
-        let endpoint = UserAPI.getUsersForPage(page)
+        let endpoint = UserAPI.readUsersForPage(page)
         let net = network.observableRequest(endpoint).map([NETUser].self, atKeyPath: "data").mapToDatabase().save(to: database)
         return sourceType.result(db: db.mapToDomain(), net: net.mapToDomain())
     }

--- a/ios/DataLayer/Tests/DataLayerTests/Repositories/AuthTokenRepositoryTests.swift
+++ b/ios/DataLayer/Tests/DataLayerTests/Repositories/AuthTokenRepositoryTests.swift
@@ -22,8 +22,8 @@ class AuthTokenRepositoryTests: BaseTestCase {
     override func setupDependencies() {
         super.setupDependencies()
         
-        Given(keychainProvider, .get(.value(.authToken), willReturn: AuthToken.stub.token))
-        Given(keychainProvider, .get(.value(.userId), willReturn: AuthToken.stub.userId))
+        Given(keychainProvider, .read(.value(.authToken), willReturn: AuthToken.stub.token))
+        Given(keychainProvider, .read(.value(.userId), willReturn: AuthToken.stub.userId))
     }
     
     private func createRepository() -> AuthTokenRepository {
@@ -43,8 +43,8 @@ class AuthTokenRepositoryTests: BaseTestCase {
         
         XCTAssertEqual(authToken, AuthToken.stub)
         XCTAssertEqual(networkProvider.requestCallsCount, 1)
-        Verify(keychainProvider, 1, .save(.value(.authToken), value: .value(AuthToken.stub.token)))
-        Verify(keychainProvider, 1, .save(.value(.userId), value: .value(AuthToken.stub.userId)))
+        Verify(keychainProvider, 1, .update(.value(.authToken), value: .value(AuthToken.stub.token)))
+        Verify(keychainProvider, 1, .update(.value(.userId), value: .value(AuthToken.stub.userId)))
     }
     
     func testCreateRxValid() {
@@ -59,8 +59,8 @@ class AuthTokenRepositoryTests: BaseTestCase {
             .completed(0)
         ])
         XCTAssertEqual(networkProvider.requestCallsCount, 1)
-        Verify(keychainProvider, 1, .save(.value(.authToken), value: .value(AuthToken.stub.token)))
-        Verify(keychainProvider, 1, .save(.value(.userId), value: .value(AuthToken.stub.userId)))
+        Verify(keychainProvider, 1, .update(.value(.authToken), value: .value(AuthToken.stub.token)))
+        Verify(keychainProvider, 1, .update(.value(.userId), value: .value(AuthToken.stub.userId)))
     }
     
     func testCreateInvalidPassword() async throws {
@@ -73,7 +73,7 @@ class AuthTokenRepositoryTests: BaseTestCase {
         } catch {
             XCTAssertEqual(error as? RepositoryError, RepositoryError(statusCode: StatusCode.httpUnathorized, message: ""))
             XCTAssertEqual(networkProvider.requestCallsCount, 1)
-            Verify(keychainProvider, 0, .save(.any, value: .any))
+            Verify(keychainProvider, 0, .update(.any, value: .any))
         }
     }
     
@@ -89,7 +89,7 @@ class AuthTokenRepositoryTests: BaseTestCase {
             .error(0, RepositoryError(statusCode: StatusCode.httpUnathorized, message: ""))
         ])
         XCTAssertEqual(networkProvider.requestCallsCount, 1)
-        Verify(keychainProvider, 0, .save(.any, value: .any))
+        Verify(keychainProvider, 0, .update(.any, value: .any))
     }
     
     func testRead() {
@@ -98,8 +98,8 @@ class AuthTokenRepositoryTests: BaseTestCase {
         let output = repository.read()
         
         XCTAssertEqual(output, AuthToken.stub)
-        Verify(keychainProvider, 1, .get(.value(.userId)))
-        Verify(keychainProvider, 1, .get(.value(.authToken)))
+        Verify(keychainProvider, 1, .read(.value(.userId)))
+        Verify(keychainProvider, 1, .read(.value(.authToken)))
     }
     
     func testDelete() {

--- a/ios/DataLayer/Tests/DataLayerTests/Repositories/RemoteConfigRepositoryTests.swift
+++ b/ios/DataLayer/Tests/DataLayerTests/Repositories/RemoteConfigRepositoryTests.swift
@@ -18,7 +18,7 @@ class RemoteConfigRepositoryTests: BaseTestCase {
     override func setupDependencies() {
         super.setupDependencies()
         
-        Given(remoteConfigProvider, .get(.any, willReturn: .just(true)))
+        Given(remoteConfigProvider, .read(.any, willReturn: .just(true)))
     }
     
     // MARK: Tests
@@ -34,6 +34,6 @@ class RemoteConfigRepositoryTests: BaseTestCase {
             .next(0, true),
             .completed(0)
         ])
-        Verify(remoteConfigProvider, 1, .get(.any))
+        Verify(remoteConfigProvider, 1, .read(.any))
     }
 }

--- a/ios/DataLayer/Tests/DataLayerTests/Repositories/UserRepositoryTests.swift
+++ b/ios/DataLayer/Tests/DataLayerTests/Repositories/UserRepositoryTests.swift
@@ -114,7 +114,7 @@ class UserRepositoryTests: BaseTestCase {
         databaseProvider.observableCollectionReturnValue = User.stubList.map { $0.databaseModel }
         let output = scheduler.createObserver([User].self)
 
-        repository.list(.local, page: 0, sortBy: "id").bind(to: output).disposed(by: disposeBag)
+        repository.read(.local, page: 0, sortBy: "id").bind(to: output).disposed(by: disposeBag)
         scheduler.start()
         
         XCTAssertEqual(output.events, [
@@ -130,7 +130,7 @@ class UserRepositoryTests: BaseTestCase {
         let repository = createRepository()
         let output = scheduler.createObserver([User].self)
 
-        repository.list(.remote, page: 0, sortBy: "id").bind(to: output).disposed(by: disposeBag)
+        repository.read(.remote, page: 0, sortBy: "id").bind(to: output).disposed(by: disposeBag)
         scheduler.start()
         
         XCTAssertEqual(output.events, [
@@ -147,7 +147,7 @@ class UserRepositoryTests: BaseTestCase {
         databaseProvider.observableCollectionReturnValue = User.stubList.map { $0.databaseModel }
         let output = scheduler.createObserver([User].self)
 
-        repository.list(.both, page: 0, sortBy: "id").bind(to: output).disposed(by: disposeBag)
+        repository.read(.both, page: 0, sortBy: "id").bind(to: output).disposed(by: disposeBag)
         scheduler.start()
         
         XCTAssertEqual(output.events, [

--- a/ios/DomainLayer/Sources/DomainLayer/Repositories/UserRepository.swift
+++ b/ios/DomainLayer/Sources/DomainLayer/Repositories/UserRepository.swift
@@ -8,6 +8,6 @@ import RxSwift
 public protocol UserRepository: AutoMockable {
     func create(_ data: RegistrationData) -> Observable<User>
     func read(_ sourceType: SourceType, id: String) -> Observable<User>
-    func list(_ sourceType: SourceType, page: Int, sortBy: String?) -> Observable<[User]>
+    func read(_ sourceType: SourceType, page: Int, sortBy: String?) -> Observable<[User]>
     func update(_ sourceType: SourceType, user: User) -> Observable<User>
 }

--- a/ios/DomainLayer/Sources/DomainLayer/UseCases/Users/GetUsersUseCase.swift
+++ b/ios/DomainLayer/Sources/DomainLayer/UseCases/Users/GetUsersUseCase.swift
@@ -18,6 +18,6 @@ public struct GetUsersUseCaseImpl: GetUsersUseCase {
     }
     
     public func execute() -> Observable<[User]> {
-        userRepository.list(.local, page: 0, sortBy: "id")
+        userRepository.read(.local, page: 0, sortBy: "id")
     }
 }

--- a/ios/DomainLayer/Sources/DomainLayer/UseCases/Users/RefreshUsersUseCase.swift
+++ b/ios/DomainLayer/Sources/DomainLayer/UseCases/Users/RefreshUsersUseCase.swift
@@ -18,6 +18,6 @@ public struct RefreshUsersUseCaseImpl: RefreshUsersUseCase {
     }
     
     public func execute(page: Int) -> Observable<Int> {
-        userRepository.list(.remote, page: page, sortBy: nil).map { $0.count }
+        userRepository.read(.remote, page: page, sortBy: nil).map { $0.count }
     }
 }

--- a/ios/DomainLayer/Tests/DomainLayerTests/UseCases/Users/GetUsersUseCaseTests.swift
+++ b/ios/DomainLayer/Tests/DomainLayerTests/UseCases/Users/GetUsersUseCaseTests.swift
@@ -19,7 +19,7 @@ class GetUsersUseCaseTests: BaseTestCase {
     override func setupDependencies() {
         super.setupDependencies()
         
-        Given(userRepository, .list(.value(.local), page: .any, sortBy: .any, willReturn: .just(User.stubList)))
+        Given(userRepository, .read(.value(.local), page: .any, sortBy: .any, willReturn: .just(User.stubList)))
     }
     
     // MARK: Tests
@@ -35,6 +35,6 @@ class GetUsersUseCaseTests: BaseTestCase {
             .next(0, User.stubList),
             .completed(0)
         ])
-        Verify(userRepository, 1, .list(.value(.local), page: 0, sortBy: "id"))
+        Verify(userRepository, 1, .read(.value(.local), page: 0, sortBy: "id"))
     }
 }

--- a/ios/DomainLayer/Tests/DomainLayerTests/UseCases/Users/RefreshUsersUseCaseTests.swift
+++ b/ios/DomainLayer/Tests/DomainLayerTests/UseCases/Users/RefreshUsersUseCaseTests.swift
@@ -19,7 +19,7 @@ class RefreshUsersUseCaseTests: BaseTestCase {
     override func setupDependencies() {
         super.setupDependencies()
         
-        Given(userRepository, .list(.value(.remote), page: .any, sortBy: .any, willReturn: .just(User.stubList)))
+        Given(userRepository, .read(.value(.remote), page: .any, sortBy: .any, willReturn: .just(User.stubList)))
     }
     
     // MARK: Tests
@@ -35,6 +35,6 @@ class RefreshUsersUseCaseTests: BaseTestCase {
             .next(0, true),
             .completed(0)
         ])
-        Verify(userRepository, 1, .list(.value(.remote), page: 0, sortBy: nil))
+        Verify(userRepository, 1, .read(.value(.remote), page: 0, sortBy: nil))
     }
 }


### PR DESCRIPTION
# :pencil: Description
- This PR makes some minor naming changes in order to make our DataLayer more CRUD-like

# :bulb: What’s new?
- As we recently discussed, we want to stick with [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) (Create/Read/Update/Delete) naming pattern as much as possible in our DataLayer.

# :no_mouth: What’s missing?
- Nothing

# :books: References
- None
