### PR TITLE
Improve Formatter

### DIFF
--- a/ios/DataLayer/Sources/DataLayer/Extensions/String+Extensions.swift
+++ b/ios/DataLayer/Sources/DataLayer/Extensions/String+Extensions.swift
@@ -3,10 +3,16 @@
 //  Copyright © 2018 Matee. All rights reserved.
 //
 
+import DomainLayer
 import Foundation
 
 extension String {
     var utf8Encoded: Data {
         data(using: .utf8)!
+    }
+    
+    /// Conversion from String to Date using a given formatter.
+    func toDate(formatter: DateFormatter = Formatter.Date.default) -> Date? {
+        formatter.date(from: self)
     }
 }

--- a/ios/DomainLayer/Sources/DomainLayer/Utilities/Formatter.swift
+++ b/ios/DomainLayer/Sources/DomainLayer/Utilities/Formatter.swift
@@ -5,29 +5,22 @@
 
 import Foundation
 
-enum DateTemplate: String {
-    case ddMMyyyyHHmm
-    case ddMMyyyy
-    case HHmm
-}
-
-enum DateFormat: String {
-    case ddMMyyyyHHmm = "dd. MM. yyyy, HH:mm"
-    case ddMMyyyy = "dd. MM. yyyy"
-    case HHmm = "HH:mm"
-}
-
 /// Helper for defining global formatters
 /// - It is expensive to recreate formatters everytime you need them, so it is a good idea to hold them here
 /// - Idea taken from [ChibiCode](http://www.chibicode.org/?p=41)
-struct Formatter {
+public struct Formatter {
     
-    static let iso8601 = ISO8601DateFormatter()
-    static let dateDefault = createDateFormatter()
-    static let numberDefault = createNumberFormatter()
+    public enum Date {
+        public static let iso8601 = ISO8601DateFormatter()
+        public static let `default` = createDateFormatter()
+    }
+    
+    public enum Number {
+        public static let `default` = createNumberFormatter()
+    }
     
     /// Creates a DateFormatter based on a given date and time styles.
-    static func createDateFormatter(
+    private static func createDateFormatter(
         dateStyle: DateFormatter.Style = .medium,
         timeStyle: DateFormatter.Style = .short
     ) -> DateFormatter {
@@ -39,23 +32,23 @@ struct Formatter {
     }
     
     /// Creates a DateFormatter based on a given template.
-    static func createDateFormatter(template: DateTemplate) -> DateFormatter {
+    private static func createDateFormatter(template: String) -> DateFormatter {
         let formatter = DateFormatter()
-        formatter.dateFormat = DateFormatter.dateFormat(fromTemplate: template.rawValue, options: 0, locale: formatter.locale)
+        formatter.dateFormat = DateFormatter.dateFormat(fromTemplate: template, options: 0, locale: formatter.locale)
         formatter.doesRelativeDateFormatting = true
         return formatter
     }
     
     /// Creates a DateFormatter based on a given date format.
     /// - Please note that this conversion does not respect user's locale/preferences.
-    static func createDateFormatter(dateFormat: DateFormat) -> DateFormatter {
+    private static func createDateFormatter(dateFormat: String) -> DateFormatter {
         let formatter = DateFormatter()
-        formatter.dateFormat = dateFormat.rawValue
+        formatter.dateFormat = dateFormat
         return formatter
     }
     
     /// Creates a NumberFormatter based on a given number style.
-    static func createNumberFormatter(
+    private static func createNumberFormatter(
         numberStyle: NumberFormatter.Style = .decimal,
         separator: String? = nil
     ) -> NumberFormatter {

--- a/ios/PresentationLayer/Sources/PresentationLayer/Extensions/Date+Extensions.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/Extensions/Date+Extensions.swift
@@ -3,12 +3,13 @@
 //  Copyright © 2019 Matee. All rights reserved.
 //
 
+import DomainLayer
 import Foundation
 
 extension Date {
     
     /// Conversion from Date to String using a given formatter.
-    func toString(formatter: DateFormatter = Formatter.dateDefault) -> String {
+    func toString(formatter: DateFormatter = Formatter.Date.default) -> String {
         formatter.string(from: self)
     }
     

--- a/ios/PresentationLayer/Sources/PresentationLayer/Extensions/Int+Extensions.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/Extensions/Int+Extensions.swift
@@ -3,12 +3,13 @@
 //  Copyright © 2018 Matee. All rights reserved.
 //
 
+import DomainLayer
 import Foundation
 
 extension Int {
     
     /// Conversion from Int to String using a given formatter.
-    func toString(formatter: NumberFormatter = Formatter.numberDefault) -> String {
+    func toString(formatter: NumberFormatter = Formatter.Number.default) -> String {
         formatter.string(from: NSNumber(value: self)) ?? ""
     }
 }

--- a/ios/PresentationLayer/Sources/PresentationLayer/Extensions/String+Extensions.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/Extensions/String+Extensions.swift
@@ -18,11 +18,6 @@ extension String {
         return userInitials
     }
     
-    /// Conversion from String to Date using a given formatter.
-    func toDate(formatter: DateFormatter = Formatter.dateDefault) -> Date? {
-        formatter.date(from: self)
-    }
-    
     ///
     /// Checks whether a given email is valid
     ///


### PR DESCRIPTION
# :pencil: Description
- This PR introduces some minor changes to `Formatter` in order to make it more effective

# :bulb: What’s new?
- Creating or changing DateFormatter or NumberFormatter is quite expensive (see references), therefore it is a good idea to create them once for each needed format and then reuse them. We already have that option available in our `Formatter` helper, but we also have the option to create a new formatter through its functions.
- Now those functions are marked as private, forcing us to create any new formatter as a part of `Formatter.Date` or `Formatter.Number` enums and then reuse them.

# :no_mouth: What’s missing?
- Nothing

# :books: References
- http://chibicode.org/?p=41
- https://stackoverflow.com/questions/28504589/creating-an-nsdateformatter-in-swift
