### PR TITLE
Clean error handling

### DIFF
--- a/ios/DataLayer/Sources/DataLayer/Errors/AuthError.swift
+++ b/ios/DataLayer/Sources/DataLayer/Errors/AuthError.swift
@@ -1,0 +1,18 @@
+//
+//  Created by Petr Chmelar on 16.05.2022
+//  Copyright © 2022 Matee. All rights reserved.
+//
+
+import DomainLayer
+import Foundation
+
+extension AuthError {
+    init(_ error: Error) {
+        switch error {
+        case let NetworkProviderError.requestFailed(statusCode, _) where statusCode == .unathorized:
+            self = .invalidCredentials
+        default:
+            self = .failed
+        }
+    }
+}

--- a/ios/DataLayer/Sources/DataLayer/Extensions/Encodable+Extensions.swift
+++ b/ios/DataLayer/Sources/DataLayer/Extensions/Encodable+Extensions.swift
@@ -14,4 +14,12 @@ extension Encodable {
         guard let data = data else { return nil }
         return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
     }
+    
+    func encode() throws -> [String: Any] {
+        let data = try JSONEncoder().encode(self)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw EncodingError.invalidValue(data, .init(codingPath: [], debugDescription: "Object can't be encoded"))
+        }
+        return json
+    }
 }

--- a/ios/DataLayer/Sources/DataLayer/Providers/Network/NetworkProviderError.swift
+++ b/ios/DataLayer/Sources/DataLayer/Providers/Network/NetworkProviderError.swift
@@ -1,0 +1,8 @@
+//
+//  Created by Petr Chmelar on 13.05.2022
+//  Copyright © 2022 Matee. All rights reserved.
+//
+
+public enum NetworkProviderError: Error {
+    case requestFailed(statusCode: NetworkStatusCode, message: String)
+}

--- a/ios/DataLayer/Sources/DataLayer/Providers/Network/NetworkStatusCode.swift
+++ b/ios/DataLayer/Sources/DataLayer/Providers/Network/NetworkStatusCode.swift
@@ -1,0 +1,15 @@
+//
+//  Created by Petr Chmelar on 13.05.2022
+//  Copyright © 2022 Matee. All rights reserved.
+//
+
+public enum NetworkStatusCode: Int {
+    case badRequest = 400
+    case unathorized = 401
+    case forbidden = 403
+    case notFound = 404
+    case methodNotAllowed = 405
+    case conflict = 409
+    case internalServerError = 500
+    case unknown = 0
+}

--- a/ios/DataLayer/Sources/DataLayer/Providers/NewDatabase/NewDatabaseProviderError.swift
+++ b/ios/DataLayer/Sources/DataLayer/Providers/NewDatabase/NewDatabaseProviderError.swift
@@ -1,0 +1,9 @@
+//
+//  Created by Petr Chmelar on 16.05.2022
+//  Copyright © 2022 Matee. All rights reserved.
+//
+
+public enum NewDatabaseProviderError: Error {
+    case typeNotRepresentable
+    case objectNotFound
+}

--- a/ios/DataLayer/Sources/DataLayer/Providers/NewDatabase/NewRealmDatabaseProvider.swift
+++ b/ios/DataLayer/Sources/DataLayer/Providers/NewDatabase/NewRealmDatabaseProvider.swift
@@ -39,17 +39,17 @@ public struct NewRealmDatabaseProvider {
 
 extension NewRealmDatabaseProvider: NewDatabaseProvider {
     public func read<T>(_ type: T.Type, id: String) throws -> T {
-        guard let realmType = T.self as? Object.Type else { throw CommonError.realmNotAvailable }
+        guard let realmType = T.self as? Object.Type else { throw NewDatabaseProviderError.typeNotRepresentable }
         let realm = try Realm()
         if let object = realm.object(ofType: realmType.self, forPrimaryKey: id) as? T {
             return object
         } else {
-            throw CommonError.realmNotAvailable
+            throw NewDatabaseProviderError.objectNotFound
         }
     }
     
     public func read<T>(_ type: T.Type, predicate: NSPredicate?, sortBy: String?, ascending: Bool) throws -> [T] {
-        guard let realmType = T.self as? Object.Type else { throw CommonError.realmNotAvailable }
+        guard let realmType = T.self as? Object.Type else { throw NewDatabaseProviderError.typeNotRepresentable }
         
         let realm = try Realm()
         var realmObjects = realm.objects(realmType.self)
@@ -65,13 +65,13 @@ extension NewRealmDatabaseProvider: NewDatabaseProvider {
         if let objects = Array(realmObjects) as? [T] {
             return objects
         } else {
-            throw CommonError.realmNotAvailable
+            return []
         }
     }
     
     @discardableResult
     public func update<T>(_ object: T, model: UpdateModel) throws -> T {
-        guard let realmObject = object as? Object else { throw CommonError.realmNotAvailable }
+        guard let realmObject = object as? Object else { throw NewDatabaseProviderError.typeNotRepresentable }
         let realm = try Realm()
         try realm.write {
             realm.create(type(of: realmObject).self, value: model.value(for: realmObject), update: .modified)
@@ -88,7 +88,7 @@ extension NewRealmDatabaseProvider: NewDatabaseProvider {
     }
     
     public func delete<T>(_ object: T) throws {
-        guard let realmObject = object as? Object else { throw CommonError.realmNotAvailable }
+        guard let realmObject = object as? Object else { throw NewDatabaseProviderError.typeNotRepresentable }
         let realm = try Realm()
         try realm.write {
             realm.delete(realmObject)

--- a/ios/DataLayer/Sources/DataLayer/Repositories/AuthTokenRepository.swift
+++ b/ios/DataLayer/Sources/DataLayer/Repositories/AuthTokenRepository.swift
@@ -23,11 +23,13 @@ public struct AuthTokenRepositoryImpl: AuthTokenRepository {
     }
     
     public func create(_ data: LoginData) async throws -> AuthToken {
-        guard let data = data.networkModel.encoded else { throw CommonError.encoding }
-        let authToken = try await network.request(AuthAPI.login(data), withInterceptor: false).map(NETAuthToken.self).domainModel
-        keychain.update(.authToken, value: authToken.token)
-        keychain.update(.userId, value: authToken.userId)
-        return authToken
+        do {
+            let data = try data.networkModel.encode()
+            let authToken = try await network.request(AuthAPI.login(data), withInterceptor: false).map(NETAuthToken.self).domainModel
+            keychain.update(.authToken, value: authToken.token)
+            keychain.update(.userId, value: authToken.userId)
+            return authToken
+        } catch { throw AuthError(error) }
     }
     
     public func createRx(_ data: LoginData) -> Observable<AuthToken> {

--- a/ios/DataLayer/Tests/DataLayerTests/Repositories/AuthTokenRepositoryTests.swift
+++ b/ios/DataLayer/Tests/DataLayerTests/Repositories/AuthTokenRepositoryTests.swift
@@ -65,13 +65,13 @@ class AuthTokenRepositoryTests: BaseTestCase {
     
     func testCreateInvalidPassword() async throws {
         let repository = createRepository()
-        networkProvider.requestReturnError = RepositoryError(statusCode: StatusCode.httpUnathorized, message: "")
+        networkProvider.requestReturnError = NetworkProviderError.requestFailed(statusCode: .unathorized, message: "")
         
         do {
             _ = try await repository.create(.stubInvalidPassword)
             XCTFail("Should throw")
         } catch {
-            XCTAssertEqual(error as? RepositoryError, RepositoryError(statusCode: StatusCode.httpUnathorized, message: ""))
+            XCTAssertEqual(error as? AuthError, AuthError.invalidCredentials)
             XCTAssertEqual(networkProvider.requestCallsCount, 1)
             Verify(keychainProvider, 0, .update(.any, value: .any))
         }

--- a/ios/DomainLayer/Sources/DomainLayer/Errors/AuthError.swift
+++ b/ios/DomainLayer/Sources/DomainLayer/Errors/AuthError.swift
@@ -1,0 +1,11 @@
+//
+//  Created by Petr Chmelar on 16.05.2022
+//  Copyright © 2022 Matee. All rights reserved.
+//
+
+public enum AuthError: Error {
+    case invalidEmail
+    case invalidPassword
+    case invalidCredentials
+    case failed
+}

--- a/ios/DomainLayer/Sources/DomainLayer/UseCases/Auth/LoginUseCase.swift
+++ b/ios/DomainLayer/Sources/DomainLayer/UseCases/Auth/LoginUseCase.swift
@@ -19,7 +19,13 @@ public struct LoginUseCaseImpl: LoginUseCase {
     }
     
     public func execute(_ data: LoginData) async throws {
-        _ = try await authTokenRepository.create(data)
+        if data.email.isEmpty {
+            throw AuthError.invalidEmail
+        } else if data.password.isEmpty {
+            throw AuthError.invalidPassword
+        } else {
+            _ = try await authTokenRepository.create(data)
+        }
     }
     
     public func executeRx(_ data: LoginData) -> Observable<Void> {

--- a/ios/PresentationLayer/Sources/PresentationLayer/App/Onboarding/Login/LoginViewModel.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/App/Onboarding/Login/LoginViewModel.swift
@@ -78,11 +78,6 @@ final class LoginViewModel: BaseViewModel, ViewModel, ObservableObject {
     }
 
     private func login() async {
-        guard !state.email.isEmpty && !state.password.isEmpty else {
-            state.alert = .init(title: L10n.invalid_credentials)
-            return
-        }
-        
         do {
             state.loginButtonLoading = true
             let data = LoginData(email: state.email, password: state.password)
@@ -91,8 +86,7 @@ final class LoginViewModel: BaseViewModel, ViewModel, ObservableObject {
             flowController?.handleFlow(.login(.dismiss))
         } catch {
             state.loginButtonLoading = false
-            let messages = ErrorMessages([.httpUnathorized: L10n.invalid_credentials], defaultMessage: L10n.signing_failed)
-            state.alert = .init(title: error.toString(messages))
+            state.alert = .init(title: error.localizedDescription)
         }
     }
 

--- a/ios/PresentationLayer/Sources/PresentationLayer/Errors/AuthError.swift
+++ b/ios/PresentationLayer/Sources/PresentationLayer/Errors/AuthError.swift
@@ -1,0 +1,18 @@
+//
+//  Created by Petr Chmelar on 16.05.2022
+//  Copyright © 2022 Matee. All rights reserved.
+//
+
+import DomainLayer
+import Foundation
+
+extension AuthError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .invalidEmail: return L10n.invalid_email
+        case .invalidPassword: return L10n.invalid_password
+        case .invalidCredentials: return L10n.invalid_credentials
+        case .failed: return L10n.signing_failed
+        }
+    }
+}

--- a/ios/PresentationLayer/Tests/PresentationLayerTests/ViewModels/Onboarding/LoginViewModelTests.swift
+++ b/ios/PresentationLayer/Tests/PresentationLayerTests/ViewModels/Onboarding/LoginViewModelTests.swift
@@ -24,10 +24,8 @@ class LoginViewModelTests: BaseTestCase {
         Resolver.register { self.loginUseCase as LoginUseCase }
         Resolver.register { self.trackAnalyticsEventUseCase as TrackAnalyticsEventUseCase }
         
-        Given(loginUseCase, .execute(
-            .value(.stubInvalidPassword),
-            willThrow: RepositoryError(statusCode: StatusCode.httpUnathorized, message: "")
-        ))
+        Given(loginUseCase, .execute(.value(.stubEmpty), willThrow: AuthError.invalidEmail))
+        Given(loginUseCase, .execute(.value(.stubInvalidPassword), willThrow: AuthError.invalidCredentials))
     }
 
     // MARK: Tests
@@ -50,9 +48,9 @@ class LoginViewModelTests: BaseTestCase {
         await vm.onIntent(.login).value
         
         XCTAssert(!vm.state.loginButtonLoading)
-        XCTAssertEqual(vm.state.alert, AlertData(title: L10n.invalid_credentials))
+        XCTAssertEqual(vm.state.alert, AlertData(title: L10n.invalid_email))
         XCTAssertEqual(fc.handleFlowValue, nil)
-        Verify(loginUseCase, 0, .execute(.any))
+        Verify(loginUseCase, 1, .execute(.value(.stubEmpty)))
         Verify(trackAnalyticsEventUseCase, 0, .execute(.any))
     }
     


### PR DESCRIPTION
# :pencil: Description
- This PR introduces an advanced error handling we should use together with try/catch

# :bulb: What’s new?
- Our current error handling was tailored for use with RxSwift and was designed long before we adopted Clean Architecture. As we are ditching RxSwift in favor of async/await, it makes sense to redesign our error handling.
- Every domain (Auth / User / etc) should have its own error type with various cases that can occur, take a look at `DomainLayer/Errors/AuthError`. 
- Errors produced by providers (network request failed, object not found in database, etc) should not be visible outside of DataLayer, instead they should be mapped into domain errors in the repository. Take a look at `DataLayer/Errors/AuthError` extension.
- When presenting an error to the user, we can use the standard `localizedDescription` by conforming to the `LocalizableError` protocol. Take a look at `PresentationLayer/Errors/AuthError`.

# :no_mouth: What’s missing?
- Use this error handling everywhere (once we get rid of RxSwift)
- Maybe we should change our folder structure in Domain and Data layer. Now we have folders like `UseCases/User`, `Repositories/User`, `Models/User`, etc. In bigger apps it can be a little confusing. We can organise these layers by domains instead, ie `User/UseCases`, `User/Repositories`, `User/Models` etc. Then we will have all User related stuff in one folder.

# :books: References
- https://www.avanderlee.com/swift/try-catch-throw-error-handling/
- https://stackoverflow.com/q/31443645
