### PR TITLE
Add final everywhere

### DIFF
--- a/ios/Application/AppDelegate.swift
+++ b/ios/Application/AppDelegate.swift
@@ -20,7 +20,7 @@ import Utilities
 import WidgetKit
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
+final class AppDelegate: UIResponder, UIApplicationDelegate {
     
     var window: UIWindow?
     private var flowController: AppFlowController?

--- a/ios/Application/AppFlowController.swift
+++ b/ios/Application/AppFlowController.swift
@@ -9,7 +9,7 @@ import SharedDomain
 import UIKit
 import UIToolkit
 
-class AppFlowController: FlowController, MainFlowControllerDelegate, OnboardingFlowControllerDelegate {
+final class AppFlowController: FlowController, MainFlowControllerDelegate, OnboardingFlowControllerDelegate {
     
     @Injected private var isUserLoggedUseCase: IsUserLoggedUseCase
     @Injected private var handlePushNotificationUseCase: HandlePushNotificationUseCase

--- a/ios/Application/DependencyInjection/KMPDependency.swift
+++ b/ios/Application/DependencyInjection/KMPDependency.swift
@@ -13,7 +13,7 @@ public protocol KMPDependency {
     func getProtocol<T: AnyObject>(_ proto: Protocol) -> T
 }
 
-public class KMPKoinDependency: KMPDependency {
+public final class KMPKoinDependency: KMPDependency {
     
     private var _koin: Koin_coreKoin?
     

--- a/ios/Application/MainFlowController.swift
+++ b/ios/Application/MainFlowController.swift
@@ -20,7 +20,7 @@ protocol MainFlowControllerDelegate: AnyObject {
     func presentOnboarding(animated: Bool, completion: (() -> Void)?)
 }
 
-class MainFlowController: FlowController, ProfileFlowControllerDelegate {
+final class MainFlowController: FlowController, ProfileFlowControllerDelegate {
     
     weak var delegate: MainFlowControllerDelegate?
     

--- a/ios/DataLayer/Providers/LocationProvider/Sources/LocationProvider/SystemLocationProvider.swift
+++ b/ios/DataLayer/Providers/LocationProvider/Sources/LocationProvider/SystemLocationProvider.swift
@@ -5,7 +5,7 @@
 
 import CoreLocation
 
-public class SystemLocationProvider: NSObject {
+public final class SystemLocationProvider: NSObject {
     
     private let locationManager = CLLocationManager()
     private var locationHandler: ([CLLocation]) -> Void = { _ in }

--- a/ios/DataLayer/Providers/PushNotificationsProvider/Sources/PushNotificationsProvider/FirebasePushNotificationsProvider.swift
+++ b/ios/DataLayer/Providers/PushNotificationsProvider/Sources/PushNotificationsProvider/FirebasePushNotificationsProvider.swift
@@ -9,7 +9,7 @@ import OSLog
 import UIKit
 import UserNotifications
 
-public class FirebasePushNotificationsProvider: NSObject {
+public final class FirebasePushNotificationsProvider: NSObject {
     
     private let application: UIApplication
     

--- a/ios/DataLayer/Toolkits/LocationToolkit/Sources/LocationToolkit/Repositories/LocationRepository.swift
+++ b/ios/DataLayer/Toolkits/LocationToolkit/Sources/LocationToolkit/Repositories/LocationRepository.swift
@@ -7,7 +7,7 @@ import CoreLocation
 import LocationProvider
 import SharedDomain
 
-public class LocationRepositoryImpl: LocationRepository {
+public final class LocationRepositoryImpl: LocationRepository {
     
     private let location: LocationProvider
     

--- a/ios/DataLayer/Toolkits/LocationToolkit/Tests/LocationToolkitTests/LocationRepositoryTests.swift
+++ b/ios/DataLayer/Toolkits/LocationToolkit/Tests/LocationToolkitTests/LocationRepositoryTests.swift
@@ -10,7 +10,7 @@ import LocationToolkit
 import SharedDomain
 import XCTest
 
-class LocationRepositoryTests: XCTestCase {
+final class LocationRepositoryTests: XCTestCase {
     
     private let location = CLLocation(latitude: 50.0, longitude: 50.0)
     

--- a/ios/DataLayer/Toolkits/PushNotificationsToolkit/Tests/PushNotificationsToolkitTests/PushNotificationsRepositoryTests.swift
+++ b/ios/DataLayer/Toolkits/PushNotificationsToolkit/Tests/PushNotificationsToolkitTests/PushNotificationsRepositoryTests.swift
@@ -9,7 +9,7 @@ import PushNotificationsToolkit
 import SharedDomain
 import XCTest
 
-class PushNotificationsRepositoryTests: XCTestCase {
+final class PushNotificationsRepositoryTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DataLayer/Toolkits/RemoteConfigToolkit/Tests/RemoteConfigToolkitTests/RemoteConfigRepositoryTests.swift
+++ b/ios/DataLayer/Toolkits/RemoteConfigToolkit/Tests/RemoteConfigToolkitTests/RemoteConfigRepositoryTests.swift
@@ -9,7 +9,7 @@ import RemoteConfigToolkit
 import SharedDomain
 import XCTest
 
-class RemoteConfigRepositoryTests: XCTestCase {
+final class RemoteConfigRepositoryTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DataLayer/Toolkits/UserToolkit/Sources/UserToolkit/DatabaseModels/DBUser.swift
+++ b/ios/DataLayer/Toolkits/UserToolkit/Sources/UserToolkit/DatabaseModels/DBUser.swift
@@ -6,7 +6,7 @@
 import RealmSwift
 import SharedDomain
 
-@objcMembers class DBUser: Object {
+@objcMembers final class DBUser: Object {
     dynamic var id: String = ""
     dynamic var email: String = ""
     dynamic var firstName: String = ""

--- a/ios/DataLayer/Toolkits/UserToolkit/Tests/UserToolkitTests/UserRepositoryTests.swift
+++ b/ios/DataLayer/Toolkits/UserToolkit/Tests/UserToolkitTests/UserRepositoryTests.swift
@@ -12,7 +12,7 @@ import SharedDomainMocks
 @testable import UserToolkit
 import XCTest
 
-class UserRepositoryTests: XCTestCase {
+final class UserRepositoryTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Sources/SharedDomainMocks/Mocks/UseCaseMock+Injection.swift
+++ b/ios/DomainLayer/SharedDomain/Sources/SharedDomainMocks/Mocks/UseCaseMock+Injection.swift
@@ -3,8 +3,6 @@
 //  Copyright © 2022 Matee. All rights reserved.
 //
 
-// swiftlint:disable line_length
-
 #if DEBUG
 import CoreLocation
 import Resolver
@@ -23,10 +21,11 @@ public extension Resolver {
         register { RegistrationUseCaseMock() as RegistrationUseCase }
         
         // Location
-        register { GetCurrentLocationUseCaseMock(executeReturnValue: AsyncStream(CLLocation.self) { continuation in
-            continuation.yield(CLLocation(latitude: 50.0, longitude: 50.0))
-            continuation.finish()
-        }) as GetCurrentLocationUseCase
+        register {
+            GetCurrentLocationUseCaseMock(executeReturnValue: AsyncStream(CLLocation.self) { continuation in
+                continuation.yield(CLLocation(latitude: 50.0, longitude: 50.0))
+                continuation.finish()
+            }) as GetCurrentLocationUseCase
         }
         
         // Profile

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Analytics/TrackAnalyticsEventUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Analytics/TrackAnalyticsEventUseCaseTests.swift
@@ -7,7 +7,7 @@ import SharedDomain
 import SharedDomainMocks
 import XCTest
 
-class TrackAnalyticsEventUseCaseTests: XCTestCase {
+final class TrackAnalyticsEventUseCaseTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Auth/GetProfileIdUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Auth/GetProfileIdUseCaseTests.swift
@@ -7,7 +7,7 @@ import SharedDomain
 import SharedDomainMocks
 import XCTest
 
-class GetProfileIdUseCaseTests: XCTestCase {
+final class GetProfileIdUseCaseTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Auth/IsUserLoggedUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Auth/IsUserLoggedUseCaseTests.swift
@@ -7,7 +7,7 @@ import SharedDomain
 import SharedDomainMocks
 import XCTest
 
-class IsUserLoggedUseCaseTests: XCTestCase {
+final class IsUserLoggedUseCaseTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Auth/LoginUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Auth/LoginUseCaseTests.swift
@@ -7,7 +7,7 @@ import SharedDomain
 import SharedDomainMocks
 import XCTest
 
-class LoginUseCaseTests: XCTestCase {
+final class LoginUseCaseTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Auth/LogoutUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Auth/LogoutUseCaseTests.swift
@@ -7,7 +7,7 @@ import SharedDomain
 import SharedDomainMocks
 import XCTest
 
-class LogoutUseCaseTests: XCTestCase {
+final class LogoutUseCaseTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Auth/RegistrationUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Auth/RegistrationUseCaseTests.swift
@@ -7,7 +7,7 @@ import SharedDomain
 import SharedDomainMocks
 import XCTest
 
-class RegistrationUseCaseTests: XCTestCase {
+final class RegistrationUseCaseTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Location/GetCurrentLocationUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Location/GetCurrentLocationUseCaseTests.swift
@@ -8,7 +8,7 @@ import SharedDomain
 import SharedDomainMocks
 import XCTest
 
-class GetCurrentLocationUseCaseTests: XCTestCase {
+final class GetCurrentLocationUseCaseTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Profile/GetProfileUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Profile/GetProfileUseCaseTests.swift
@@ -7,7 +7,7 @@ import SharedDomain
 import SharedDomainMocks
 import XCTest
 
-class GetProfileUseCaseTests: XCTestCase {
+final class GetProfileUseCaseTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Profile/UpdateProfileCounterUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Profile/UpdateProfileCounterUseCaseTests.swift
@@ -7,7 +7,7 @@ import SharedDomain
 import SharedDomainMocks
 import XCTest
 
-class UpdateProfileCounterUseCaseTests: XCTestCase {
+final class UpdateProfileCounterUseCaseTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/PushNotification/HandlePushNotificationUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/PushNotification/HandlePushNotificationUseCaseTests.swift
@@ -7,7 +7,7 @@ import SharedDomain
 import SharedDomainMocks
 import XCTest
 
-class HandlePushNotificationUseCaseTests: XCTestCase {
+final class HandlePushNotificationUseCaseTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/PushNotification/RegisterForPushNotificationsUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/PushNotification/RegisterForPushNotificationsUseCaseTests.swift
@@ -7,7 +7,7 @@ import SharedDomain
 import SharedDomainMocks
 import XCTest
 
-class RegisterForPushNotificationsUseCaseTests: XCTestCase {
+final class RegisterForPushNotificationsUseCaseTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/RemoteConfig/GetRemoteConfigValueUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/RemoteConfig/GetRemoteConfigValueUseCaseTests.swift
@@ -7,7 +7,7 @@ import SharedDomain
 import SharedDomainMocks
 import XCTest
 
-class GetRemoteConfigValueUseCaseTests: XCTestCase {
+final class GetRemoteConfigValueUseCaseTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/User/GetUserUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/User/GetUserUseCaseTests.swift
@@ -7,7 +7,7 @@ import SharedDomain
 import SharedDomainMocks
 import XCTest
 
-class GetUserUseCaseTests: XCTestCase {
+final class GetUserUseCaseTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/User/GetUsersUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/User/GetUsersUseCaseTests.swift
@@ -7,7 +7,7 @@ import SharedDomain
 import SharedDomainMocks
 import XCTest
 
-class GetUsersUseCaseTests: XCTestCase {
+final class GetUsersUseCaseTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/User/UpdateUserUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/User/UpdateUserUseCaseTests.swift
@@ -7,7 +7,7 @@ import SharedDomain
 import SharedDomainMocks
 import XCTest
 
-class UpdateUserUseCaseTests: XCTestCase {
+final class UpdateUserUseCaseTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Validation/ValidateEmailUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Validation/ValidateEmailUseCaseTests.swift
@@ -6,7 +6,7 @@
 import SharedDomain
 import XCTest
 
-class ValidateEmailUseCaseTests: XCTestCase {
+final class ValidateEmailUseCaseTests: XCTestCase {
     
     // MARK: Tests
     

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Validation/ValidatePasswordUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/Validation/ValidatePasswordUseCaseTests.swift
@@ -6,7 +6,7 @@
 import SharedDomain
 import XCTest
 
-class ValidatePasswordUseCaseTests: XCTestCase {
+final class ValidatePasswordUseCaseTests: XCTestCase {
     
     // MARK: Tests
     

--- a/ios/PresentationLayer/Onboarding/Sources/Onboarding/OnboardingFlowController.swift
+++ b/ios/PresentationLayer/Onboarding/Sources/Onboarding/OnboardingFlowController.swift
@@ -26,7 +26,7 @@ public protocol OnboardingFlowControllerDelegate: AnyObject {
     func setupMain()
 }
 
-public class OnboardingFlowController: FlowController {
+public final class OnboardingFlowController: FlowController {
     
     public weak var delegate: OnboardingFlowControllerDelegate?
     

--- a/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/LoginViewModelTests.swift
+++ b/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/LoginViewModelTests.swift
@@ -11,7 +11,7 @@ import UIToolkit
 import XCTest
 
 @MainActor
-class LoginViewModelTests: XCTestCase {
+final class LoginViewModelTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/RegistrationViewModelTests.swift
+++ b/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/RegistrationViewModelTests.swift
@@ -11,7 +11,7 @@ import UIToolkit
 import XCTest
 
 @MainActor
-class RegistrationViewModelTests: XCTestCase {
+final class RegistrationViewModelTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/PresentationLayer/Profile/Sources/Profile/ProfileFlowController.swift
+++ b/ios/PresentationLayer/Profile/Sources/Profile/ProfileFlowController.swift
@@ -19,7 +19,7 @@ public protocol ProfileFlowControllerDelegate: AnyObject {
     func presentOnboarding()
 }
 
-public class ProfileFlowController: FlowController {
+public final class ProfileFlowController: FlowController {
     
     public weak var delegate: ProfileFlowControllerDelegate?
     

--- a/ios/PresentationLayer/Profile/Tests/ProfileTests/ProfileViewModelTests.swift
+++ b/ios/PresentationLayer/Profile/Tests/ProfileTests/ProfileViewModelTests.swift
@@ -12,7 +12,7 @@ import UIToolkit
 import XCTest
 
 @MainActor
-class ProfileViewModelTests: XCTestCase {
+final class ProfileViewModelTests: XCTestCase {
 
     // MARK: Dependencies
     

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/RecipesFlowController.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/RecipesFlowController.swift
@@ -16,7 +16,7 @@ enum RecipesFlow: Flow, Equatable {
     }
 }
 
-public class RecipesFlowController: FlowController {
+public final class RecipesFlowController: FlowController {
 
     override public func setup() -> UIViewController {
         let vm = RecipesViewModel(flowController: self)

--- a/ios/PresentationLayer/Recipes/Tests/RecipesTests/CounterViewModelTests.swift
+++ b/ios/PresentationLayer/Recipes/Tests/RecipesTests/CounterViewModelTests.swift
@@ -11,7 +11,7 @@ import UIToolkit
 import XCTest
 
 @MainActor
-class CounterViewModelTests: XCTestCase {
+final class CounterViewModelTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/PresentationLayer/Recipes/Tests/RecipesTests/RecipesViewModelTests.swift
+++ b/ios/PresentationLayer/Recipes/Tests/RecipesTests/RecipesViewModelTests.swift
@@ -11,7 +11,7 @@ import UIToolkit
 import XCTest
 
 @MainActor
-class RecipesViewModelTests: XCTestCase {
+final class RecipesViewModelTests: XCTestCase {
     
     let fc = FlowControllerMock<RecipesFlow>(navigationController: UINavigationController())
     

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/UIKit/UIViewController/BaseNavigationController.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/UIKit/UIViewController/BaseNavigationController.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public class BaseNavigationController: UINavigationController {
+public final class BaseNavigationController: UINavigationController {
     
     private var statusBarStyle: UIStatusBarStyle = .default
     

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/UIKit/UIViewController/FullscreenImageViewController.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/UIKit/UIViewController/FullscreenImageViewController.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-class FullscreenImageViewController: BaseViewController {
+final class FullscreenImageViewController: BaseViewController {
     
     // MARK: UI components
     private var scrollView = UIScrollView()

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/UIKit/UIViewController/ImagePickerViewController.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/UIKit/UIViewController/ImagePickerViewController.swift
@@ -9,7 +9,7 @@ import UIKit
     @objc optional func photoSelected(image: UIImage?)
 }
 
-class ImagePickerViewController: BaseViewController {
+final class ImagePickerViewController: BaseViewController {
 
     // MARK: Stored properties
     var imagePickerTitle: String = L10n.image_picker_title

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/UIKit/UIViewController/SafariViewController.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/UIKit/UIViewController/SafariViewController.swift
@@ -5,7 +5,7 @@
 
 import SafariServices
 
-class SafariViewController: SFSafariViewController {
+final class SafariViewController: SFSafariViewController {
     
     // MARK: Stored properties
     private let url: URL

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/UIKit/UIViewController/WebViewController.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/UIKit/UIViewController/WebViewController.swift
@@ -6,7 +6,7 @@
 import UIKit
 import WebKit
 
-class WebViewController: BaseViewController {
+final class WebViewController: BaseViewController {
     
     // MARK: Stored properties
     private var url: URL

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/UIKit/Whisper/WhisperView.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/UIKit/Whisper/WhisperView.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-class WhisperView: UIView {
+final class WhisperView: UIView {
 
     // MARK: UI components
     private let messageLabel = UILabel()

--- a/ios/PresentationLayer/Users/Sources/Users/UsersFlowController.swift
+++ b/ios/PresentationLayer/Users/Sources/Users/UsersFlowController.swift
@@ -15,7 +15,7 @@ enum UsersFlow: Flow, Equatable {
     }
 }
 
-public class UsersFlowController: FlowController {
+public final class UsersFlowController: FlowController {
     
     override public func setup() -> UIViewController {
         let vm = UsersViewModel(flowController: self)

--- a/ios/PresentationLayer/Users/Tests/UsersTests/UserDetailViewModelTests.swift
+++ b/ios/PresentationLayer/Users/Tests/UsersTests/UserDetailViewModelTests.swift
@@ -12,7 +12,7 @@ import Utilities
 import XCTest
 
 @MainActor
-class UserDetailViewModelTests: XCTestCase {
+final class UserDetailViewModelTests: XCTestCase {
     
     // MARK: Dependencies
     

--- a/ios/PresentationLayer/Users/Tests/UsersTests/UsersViewModelTests.swift
+++ b/ios/PresentationLayer/Users/Tests/UsersTests/UsersViewModelTests.swift
@@ -12,7 +12,7 @@ import Utilities
 import XCTest
 
 @MainActor
-class UsersViewModelTests: XCTestCase {
+final class UsersViewModelTests: XCTestCase {
     
     // MARK: Dependencies
     


### PR DESCRIPTION
# :pencil: Description
- This PR adds final to every class that doesn't have an inheritance in the codebase

# :bulb: Steps to reproduce
1) Save this template as `final.swifttemplate`:
```swift
#!/usr/bin/env bash
<% for type in types.classes { -%>
<%_ if type.attributes["final"] != nil || type.attributes["open"] != nil || types.based[type.name].isEmpty == false { continue } -%>
<%_ _%>git grep -lz 'class <%= type.name %>' | xargs -0 perl -i'' -pE "s/class <%= type.name %>(?=\s|:)/final class <%= type.name %>/g"
<% } %>
```
2) Use [Sourcery](https://github.com/krzysztofzablocki/Sourcery) to generate the script:
```
sourcery --sources . --templates final.swifttemplate --output final.sh
```
3) Run the script: `./final.sh`
4) Profit! :moneybag: 

# :no_mouth: What’s missing?
- Nothing

# :books: References
- https://twitter.com/merowing_/status/1522558910648967174
