### PR TITLE
SwiftUI skeleton example

### DIFF
--- a/ios/DevStack.xcodeproj/project.pbxproj
+++ b/ios/DevStack.xcodeproj/project.pbxproj
@@ -101,7 +101,6 @@
 		4508334428454DA900BC9460 /* KMPDependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KMPDependency.swift; sourceTree = "<group>"; };
 		4524472627A417B1004853C8 /* WidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetView.swift; sourceTree = "<group>"; };
 		4534C1C42603D6AD0022ACF4 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		453580E428478CE3007AEC9E /* RocketToolkit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = RocketToolkit; sourceTree = "<group>"; };
 		453580E52847E814007AEC9E /* GraphQLProvider */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = GraphQLProvider; sourceTree = "<group>"; };
 		453580EC284806D1007AEC9E /* schema.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = schema.json; sourceTree = "<group>"; };
 		453580EE284806FE007AEC9E /* strings.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = strings.txt; path = ../../twine/strings.txt; sourceTree = "<group>"; };
@@ -132,6 +131,7 @@
 		45A0EBAA27ADF5900005A01E /* Widget+Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Widget+Injection.swift"; sourceTree = "<group>"; };
 		45B5A7942842A4E30055447B /* LocationProvider */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = LocationProvider; sourceTree = "<group>"; };
 		45B5A7952842A64D0055447B /* PushNotificationsProvider */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = PushNotificationsProvider; sourceTree = "<group>"; };
+		45BA62EE284EA7EA0060253A /* RocketToolkit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = RocketToolkit; sourceTree = "<group>"; };
 		45C120A1284292690065E6BA /* DatabaseProvider */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = DatabaseProvider; sourceTree = "<group>"; };
 		45DEBE1827A153A10075C7E2 /* DevStack Widget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "DevStack Widget.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		45DEBE1927A153A10075C7E2 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
@@ -385,7 +385,7 @@
 				456F8B042842CB2800F74A61 /* LocationToolkit */,
 				456F8B052842CC7800F74A61 /* PushNotificationsToolkit */,
 				456F8B062842CDFF00F74A61 /* RemoteConfigToolkit */,
-				453580E428478CE3007AEC9E /* RocketToolkit */,
+				45BA62EE284EA7EA0060253A /* RocketToolkit */,
 				456F8B072842CF1000F74A61 /* UserToolkit */,
 			);
 			path = Toolkits;

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/Main/RecipesViewModel.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/Main/RecipesViewModel.swift
@@ -10,6 +10,7 @@ enum Recipe: String, CaseIterable {
     case counter = "Counter"
     case books = "Books"
     case rocketLaunches = "RocketLaunches"
+    case skeleton = "Skeleton"
 }
 
 final class RecipesViewModel: BaseViewModel, ViewModel, ObservableObject {
@@ -53,6 +54,8 @@ final class RecipesViewModel: BaseViewModel, ViewModel, ObservableObject {
             flowController?.handleFlow(RecipesFlow.recipes(.showBooks))
         case .rocketLaunches:
             flowController?.handleFlow(RecipesFlow.recipes(.showRocketLaunches))
+        case .skeleton:
+            flowController?.handleFlow(RecipesFlow.recipes(.showSkeleton))
         }
     }
 }

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/RecipesFlowController.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/RecipesFlowController.swift
@@ -14,6 +14,7 @@ enum RecipesFlow: Flow, Equatable {
         case showCounter
         case showBooks
         case showRocketLaunches
+        case showSkeleton
     }
 }
 
@@ -39,6 +40,7 @@ extension RecipesFlowController {
         case .showCounter: showCounter()
         case .showBooks: showBooks()
         case .showRocketLaunches: showRocketLaunches()
+        case .showSkeleton: showSkeleton()
         }
     }
     
@@ -57,6 +59,12 @@ extension RecipesFlowController {
     private func showRocketLaunches() {
         let vm = RocketLaunchesViewModel(flowController: self)
         let vc = BaseHostingController(rootView: RocketLaunchesView(viewModel: vm))
+        navigationController.show(vc, sender: nil)
+    }
+    
+    private func showSkeleton() {
+        let vm = SkeletonViewModel(flowController: self)
+        let vc = BaseHostingController(rootView: SkeletonView(viewModel: vm))
         navigationController.show(vc, sender: nil)
     }
 }

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/Skeleton/SkeletonView.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/Skeleton/SkeletonView.swift
@@ -1,0 +1,41 @@
+//
+//  Created by Petr Chmelar on 07.06.2022
+//  Copyright © 2022 Matee. All rights reserved.
+//
+
+import SwiftUI
+import UIToolkit
+
+struct SkeletonView: View {
+    
+    @ObservedObject private var viewModel: SkeletonViewModel
+    
+    init(viewModel: SkeletonViewModel) {
+        self.viewModel = viewModel
+    }
+    
+    var body: some View {
+        return VStack {
+            HeadlineText(viewModel.state.title ?? .placeholder(length: 10))
+                .skeleton(viewModel.state.title == nil)
+        }
+        .lifecycle(viewModel)
+        .navigationTitle(L10n.skeleton_view_toolbar_title)
+    }
+}
+
+#if DEBUG
+import Resolver
+import SharedDomainMocks
+
+struct SkeletonView_Previews: PreviewProvider {
+    static var previews: some View {
+        Resolver.registerUseCaseMocks()
+        
+        let vm = SkeletonViewModel(flowController: nil)
+        return PreviewGroup {
+            SkeletonView(viewModel: vm)
+        }
+    }
+}
+#endif

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/Skeleton/SkeletonViewModel.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/Skeleton/SkeletonViewModel.swift
@@ -1,0 +1,48 @@
+//
+//  Created by Petr Chmelar on 07.06.2022
+//  Copyright © 2022 Matee. All rights reserved.
+//
+
+import SwiftUI
+import UIToolkit
+
+final class SkeletonViewModel: BaseViewModel, ViewModel, ObservableObject {
+    
+    // MARK: Dependencies
+    private weak var flowController: FlowController?
+
+    init(flowController: FlowController?) {
+        self.flowController = flowController
+        super.init()
+    }
+    
+    // MARK: Lifecycle
+    
+    override func onAppear() {
+        super.onAppear()
+        executeTask(Task { await loadTitle() })
+    }
+    
+    // MARK: State
+    
+    @Published private(set) var state: State = State()
+
+    struct State {
+        var title: String?
+    }
+    
+    // MARK: Intent
+    enum Intent {
+    }
+
+    func onIntent(_ intent: Intent) {}
+    
+    // MARK: Private
+    
+    private func loadTitle() async {
+        do {
+            try await Task.sleep(nanoseconds: 3000000000)
+            state.title = "Some title"
+        } catch {}
+    }
+}

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/Shimmer/Shimmer.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/Shimmer/Shimmer.swift
@@ -1,0 +1,101 @@
+//
+//  Shimmer.swift
+//
+//  Created by Vikram Kriplaney on 23.03.21.
+//
+
+// Taken from: https://github.com/markiv/SwiftUI-Shimmer
+
+import SwiftUI
+
+/// A view modifier that applies an animated "shimmer" to any view, typically to show that
+/// an operation is in progress.
+public struct Shimmer: ViewModifier {
+    @State private var phase: CGFloat = 0
+    var duration = 1.5
+    var bounce = false
+
+    public func body(content: Content) -> some View {
+        content
+            .modifier(AnimatedMask(phase: phase).animation(
+                Animation.linear(duration: duration)
+                    .repeatForever(autoreverses: bounce)
+            ))
+            .onAppear { phase = 0.8 }
+    }
+
+    /// An animatable modifier to interpolate between `phase` values.
+    struct AnimatedMask: AnimatableModifier {
+        var phase: CGFloat = 0
+
+        var animatableData: CGFloat {
+            get { phase }
+            set { phase = newValue }
+        }
+
+        func body(content: Content) -> some View {
+            content
+                .mask(GradientMask(phase: phase).scaleEffect(3))
+        }
+    }
+
+    /// A slanted, animatable gradient between transparent and opaque to use as mask.
+    /// The `phase` parameter shifts the gradient, moving the opaque band.
+    struct GradientMask: View {
+        let phase: CGFloat
+        let centerColor = Color.black
+        let edgeColor = Color.black.opacity(0.5)
+
+        var body: some View {
+            LinearGradient(
+                gradient: Gradient(stops: [
+                    .init(color: edgeColor, location: phase),
+                    .init(color: centerColor, location: phase + 0.1),
+                    .init(color: edgeColor, location: phase + 0.2)
+                ]),
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        }
+    }
+}
+
+public extension View {
+    /// Adds an animated shimmering effect to any view, typically to show that
+    /// an operation is in progress.
+    /// - Parameters:
+    ///   - active: Convenience parameter to conditionally enable the effect. Defaults to `true`.
+    ///   - duration: The duration of a shimmer cycle in seconds. Default: `1.5`.
+    ///   - bounce: Whether to bounce (reverse) the animation back and forth. Defaults to `false`.
+    @ViewBuilder func shimmering(
+        active: Bool = true, duration: Double = 1.5, bounce: Bool = false
+    ) -> some View {
+        if active {
+            modifier(Shimmer(duration: duration, bounce: bounce))
+        } else {
+            self
+        }
+    }
+}
+
+#if DEBUG
+struct Shimmer_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            Text("SwiftUI Shimmer")
+            if #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *) {
+                Text("SwiftUI Shimmer").preferredColorScheme(.light)
+                Text("SwiftUI Shimmer").preferredColorScheme(.dark)
+                VStack(alignment: .leading) {
+                    Text("Loading...").font(.title)
+                    Text(String(repeating: "Shimmer", count: 12))
+                        .redacted(reason: .placeholder)
+                }.frame(maxWidth: 200)
+            }
+        }
+        .padding()
+        .shimmering()
+        .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/Extensions/String+Extensions.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/Extensions/String+Extensions.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension String {
+public extension String {
     
     var secured: String {
         String(map { _ in "*" })
@@ -16,6 +16,10 @@ extension String {
         let initials = words.map { String($0.first ?? Character("")) }
         let userInitials = initials.joined()
         return userInitials
+    }
+    
+    static func placeholder(length: Int) -> String {
+        String(Array(repeating: "X", count: length))
     }
     
     ///

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/Extensions/View+Extensions.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/Extensions/View+Extensions.swift
@@ -17,3 +17,17 @@ public extension View {
             }
     }
 }
+
+public extension View {
+    /// Redact a view with a shimmering effect aka show a skeleton
+    /// - Inspiration taken from [Redacted View Modifier](https://www.avanderlee.com/swiftui/redacted-view-modifier/)
+    @ViewBuilder
+    func skeleton(
+        _ condition: @autoclosure () -> Bool,
+        duration: Double = 1.5,
+        bounce: Bool = false
+    ) -> some View {
+        redacted(reason: condition() ? .placeholder : [])
+            .shimmering(active: condition(), duration: duration, bounce: bounce)
+    }
+}

--- a/twine/strings.txt
+++ b/twine/strings.txt
@@ -745,6 +745,12 @@
         cs = Starty raket
         en = Rocket launches
         sk = Štarty rakiet
+        
+[[Skeleton View]]
+    [skeleton_view_toolbar_title]
+        cs = Skeleton
+        en = Skeleton
+        sk = Skeleton
 
 [[User Detail View]]
 	[user_detail_view_toolbar_title]


### PR DESCRIPTION
# :pencil: Description
- This PR adds a basic implementation of the SwiftUI skeleton ☠️ 

# :bulb: What’s new?
- SwiftUI has built-in support for so-called skeleton views by using a `.redacted` modifier together with providing a placeholder copy for optional values.
- However this results only in static skeletons with no animations, therefore I added a basic shimmering effect. It is taken from [SwiftUI-Shimmer](https://github.com/markiv/SwiftUI-Shimmer), but I copied it into our project in order to avoid adding another dependency. Also, we can easily change its behavior if needed.
- For easier usage, I combined these two modifiers into a `.skeleton` modifier.
- Example of usage in `SkeletonView` + `SkeletonViewModel`

# :no_mouth: What’s missing?
- Nothing

# :books: References
- https://www.avanderlee.com/swiftui/redacted-view-modifier/
- https://github.com/markiv/SwiftUI-Shimmer
