### PR TITLE
Fix Firebase Analytics debug mode

### DIFF
--- a/ios/Application/AppDelegate.swift
+++ b/ios/Application/AppDelegate.swift
@@ -41,6 +41,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         // Clear keychain on first run
         clearKeychain()
         
+        // Setup firebase for debug
+        firebaseDebugSetup()
+        
         // Init main window with navigation controller
         let nc = BaseNavigationController(statusBarStyle: .lightContent)
         nc.navigationBar.isHidden = true
@@ -113,6 +116,17 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
                 try userDefaultsProvider.update(.hasRunBefore, value: true)
             }
         } catch {}
+    }
+    
+    // MARK: Firebase debug setup
+    private func firebaseDebugSetup() {
+        // Enable Firebase Analytics debug mode for non production environments
+        // Idea taken from: https://stackoverflow.com/a/47594030/6947225
+        if Environment.type != .production {
+            var args = ProcessInfo.processInfo.arguments
+            args.append("-FIRAnalyticsDebugEnabled")
+            ProcessInfo.processInfo.setValue(args, forKey: "arguments")
+        }
     }
 }
 

--- a/ios/Application/DependencyInjection/Providers+Injection.swift
+++ b/ios/Application/DependencyInjection/Providers+Injection.swift
@@ -23,12 +23,7 @@ public extension Resolver {
         appDelegate: (UIApplicationDelegate & UNUserNotificationCenterDelegate),
         networkProviderDelegate: NetworkProviderDelegate
     ) {
-        register {
-            FirebaseAnalyticsProvider(
-                debugMode: Environment.type != .production,
-                processInfo: ProcessInfo.processInfo
-            ) as AnalyticsProvider
-        }
+        register { FirebaseAnalyticsProvider() as AnalyticsProvider }
         register { RealmDatabaseProvider() as DatabaseProvider }
         register { ApolloGraphQLProvider(baseURL: NetworkingConstants.rocketsURL) as GraphQLProvider }
         register { SystemKeychainProvider() as KeychainProvider }

--- a/ios/Application/DependencyInjection/Providers+Injection.swift
+++ b/ios/Application/DependencyInjection/Providers+Injection.swift
@@ -23,7 +23,12 @@ public extension Resolver {
         appDelegate: (UIApplicationDelegate & UNUserNotificationCenterDelegate),
         networkProviderDelegate: NetworkProviderDelegate
     ) {
-        register { FirebaseAnalyticsProvider(debugMode: Environment.type != .production) as AnalyticsProvider }
+        register {
+            FirebaseAnalyticsProvider(
+                debugMode: Environment.type != .production,
+                processInfo: ProcessInfo.processInfo
+            ) as AnalyticsProvider
+        }
         register { RealmDatabaseProvider() as DatabaseProvider }
         register { ApolloGraphQLProvider(baseURL: NetworkingConstants.rocketsURL) as GraphQLProvider }
         register { SystemKeychainProvider() as KeychainProvider }

--- a/ios/DataLayer/Providers/AnalyticsProvider/Sources/AnalyticsProvider/FirebaseAnalyticsProvider.swift
+++ b/ios/DataLayer/Providers/AnalyticsProvider/Sources/AnalyticsProvider/FirebaseAnalyticsProvider.swift
@@ -7,22 +7,10 @@ import Firebase
 import FirebaseAnalytics
 
 public struct FirebaseAnalyticsProvider {
-    
-    public init(
-        debugMode: Bool,
-        processInfo: ProcessInfo
-    ) {
+    public init() {
         // Start Firebase if not yet started
         if FirebaseApp.app() == nil {
             FirebaseApp.configure()
-        }
-        
-        // Enable Firebase Analytics debug mode for non production environments
-        // Idea taken from: https://stackoverflow.com/a/47594030/6947225
-        if debugMode {
-            var args = processInfo.arguments
-            args.append("-FIRAnalyticsDebugEnabled")
-            processInfo.setValue(args, forKey: "arguments")
         }
     }
 }

--- a/ios/DataLayer/Providers/AnalyticsProvider/Sources/AnalyticsProvider/FirebaseAnalyticsProvider.swift
+++ b/ios/DataLayer/Providers/AnalyticsProvider/Sources/AnalyticsProvider/FirebaseAnalyticsProvider.swift
@@ -8,7 +8,10 @@ import FirebaseAnalytics
 
 public struct FirebaseAnalyticsProvider {
     
-    public init(debugMode: Bool) {
+    public init(
+        debugMode: Bool,
+        processInfo: ProcessInfo
+    ) {
         // Start Firebase if not yet started
         if FirebaseApp.app() == nil {
             FirebaseApp.configure()
@@ -17,9 +20,9 @@ public struct FirebaseAnalyticsProvider {
         // Enable Firebase Analytics debug mode for non production environments
         // Idea taken from: https://stackoverflow.com/a/47594030/6947225
         if debugMode {
-            var args = ProcessInfo.processInfo.arguments
+            var args = processInfo.arguments
             args.append("-FIRAnalyticsDebugEnabled")
-            ProcessInfo.processInfo.setValue(args, forKey: "arguments")
+            processInfo.setValue(args, forKey: "arguments")
         }
     }
 }


### PR DESCRIPTION
# :pencil: Description
- This PR fixes Firebase Analytics debug mode

# :bulb: What’s new?
- When I [implemented](https://github.com/MateeDevs/devstack-ios-app/pull/139) Firebase Analytics we had `FirebaseAnalyticsProvider` in the app target, so setting the ProcessInfo argument works as expected. But since the modularisation, we have it in a separate Swift Package, and setting ProcessInfo arguments from there doesn't work as expected.
- The solution is to pass the `ProcessInfo` from the Application to the AnalyticsProvider package.

# :no_mouth: What’s missing?
- Nothing

# :books: References
- None
