### PR TITLE
Fix dSYM sync

### DIFF
--- a/.github/workflows/ios-dSYMs.yml
+++ b/.github/workflows/ios-dSYMs.yml
@@ -15,7 +15,7 @@ jobs:
           clean: false
       - name: Get path of Crashlytics upload-symbols
         working-directory: ios
-        run: echo "UPLOAD_SYMBOLS_PATH=`xcodebuild -project *.xcodeproj -showBuildSettings | grep -m 1 "BUILD_DIR" | grep -oEi "\/.*" | sed 's:Build/Products:SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols:' | tr -d '\n'`" >> $GITHUB_ENV
+        run: echo "UPLOAD_SYMBOLS_PATH=`xcodebuild -workspace DevStack.xcworkspace -scheme DevStack -showBuildSettings | grep -m 1 "BUILD_DIR" | grep -oEi "\/.*" | sed 's:Build/Products:SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols:' | tr -d '\n'`" >> $GITHUB_ENV
       - name: Sync Alpha dSYMs
         env:
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_MATEE }}


### PR DESCRIPTION
# :pencil: Description
- This PR improves GitHub Action for dSYM sync

# :bulb: What’s new?
- We are using `-project xyz` when determining the path to `Crashlytics/upload-symbols` script.
- This can break in projects that has some dependencies in multiple packages.
- Therefore it is more safe to use `-workspace xyz -scheme xyz`. It doesn't matter which scheme we are using because Crashlytics package is in all of them. 

# :no_mouth: What’s missing?
- Nothing

# :books: References
- https://github.com/fastlane/fastlane/issues/17288#issuecomment-840138427
