### PR TITLE
KMM build optimisations

### DIFF
--- a/.github/workflows/ios-develop.yml
+++ b/.github/workflows/ios-develop.yml
@@ -23,7 +23,7 @@ jobs:
         run: ./scripts/setup.sh
       - name: Build KMP
         working-directory: ios
-        run: ./scripts/build-kmp.sh
+        run: ./scripts/build-kmp.sh release true
       - name: Generate build number
         run: echo "BUILD_NUMBER=$(echo `date +"%y%m%d%H%M"`)" >> $GITHUB_ENV
       - name: Prepare App Store Connect API key file

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -18,7 +18,7 @@ jobs:
         run: ./scripts/setup.sh
       - name: Build KMP
         working-directory: ios
-        run: ./scripts/build-kmp.sh
+        run: ./scripts/build-kmp.sh release true
       - name: Generate build number
         run: echo "BUILD_NUMBER=$(echo `date +"%y%m%d%H%M"`)" >> $GITHUB_ENV
       - name: Prepare App Store Connect API key file

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -21,7 +21,7 @@ jobs:
         run: ./scripts/setup.sh
       - name: Build KMP
         working-directory: ios
-        run: ./scripts/build-kmp.sh
+        run: ./scripts/build-kmp.sh debug false
       - name: Run tests
         working-directory: ios
         run: fastlane test_alpha

--- a/android/login/src/main/kotlin/cz/matee/devstack/kmp/android/login/ui/AuthScreen.kt
+++ b/android/login/src/main/kotlin/cz/matee/devstack/kmp/android/login/ui/AuthScreen.kt
@@ -39,7 +39,13 @@ fun AuthScreen(navHostController: NavHostController) {
     val authVm = getViewModel<AuthViewModel>()
     val scope = rememberCoroutineScope()
     val snackBarState = remember { SnackbarHostState() }
-    val loginState = remember { AuthState() }
+    val loginState =
+        remember {
+            AuthState().apply {
+                emailValue = TextFieldValue("petr.chmelar@matee.cz")
+                passwordValue = TextFieldValue("11111111")
+            }
+        }
     val registerState = remember { AuthState() }
     var authScreen by remember { mutableStateOf(AuthScreen.Login) }
     val isLoading by authVm[LoginViewModelState::loading].collectAsState(initial = false)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,11 +1,21 @@
+val kotlinVersion = "1.7.10"
+val androidGradleVersion = "7.2.0"
+
+kotlinDslPluginOptions {
+    jvmTarget.set(JavaVersion.VERSION_1_8.toString())
+}
+
 plugins {
     `kotlin-dsl`
 }
+
 repositories {
-    jcenter()
+    gradlePluginPortal()
+    mavenCentral()
+    google()
 }
 
 dependencies {
-    "implementation"("org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.5.31")
+    implementation("com.android.tools.build:gradle:$androidGradleVersion")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
 }
-        

--- a/buildSrc/src/main/kotlin/Application.kt
+++ b/buildSrc/src/main/kotlin/Application.kt
@@ -2,9 +2,9 @@ object Application {
     const val id = "cz.matee.devstack.kmp.android"
 
     object Sdk {
-        const val min = 21
-        const val target = 31
-        const val compile = 31
+        const val min = 23
+        const val target = 33
+        const val compile = 33
     }
 
     object Version {

--- a/buildSrc/src/main/kotlin/Dependency.kt
+++ b/buildSrc/src/main/kotlin/Dependency.kt
@@ -98,6 +98,12 @@ object Dependency {
         // Features https://ktor.io/docs/http-client-features.html
         const val serialization = "io.ktor:ktor-serialization-kotlinx-json:$version"
         const val contentNegotiation = "io.ktor:ktor-client-content-negotiation:$version"
+        const val logging = "io.ktor:ktor-client-logging:$version"
+    }
+
+    object Kermit {
+        private const val version = "1.1.2"
+        const val core = "co.touchlab:kermit:$version"
     }
 
     object Matee {

--- a/buildSrc/src/main/kotlin/Dependency.kt
+++ b/buildSrc/src/main/kotlin/Dependency.kt
@@ -6,7 +6,7 @@ object Dependency {
         const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
         object Coroutines {
-            const val version = "1.6.0-RC3"
+            const val version = "1.6.0"
 
             const val common = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
             const val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$version"
@@ -22,7 +22,7 @@ object Dependency {
     }
 
     object AndroidX {
-        const val core = "androidx.core:core-ktx:1.7.0"
+        const val core = "androidx.core:core-ktx:1.9.0"
         const val testRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         object Material {
@@ -46,8 +46,8 @@ object Dependency {
     }
 
     object Compose {
-        const val version = "1.1.1"
-        const val compilerExtensionVersion = "1.2.0-alpha01"
+        const val version = "1.3.0-rc01"
+        const val compilerExtensionVersion = version
 
         const val ui = "androidx.compose.ui:ui:$version"
         const val uiTooling = "androidx.compose.ui:ui-tooling:$version"
@@ -89,14 +89,15 @@ object Dependency {
 
 
     object Ktor {
-        private const val version = "1.6.7" // do not change until compose will has a newer kotlin version - current is 1.5.31
+        private const val version = "2.1.2"
 
         const val core = "io.ktor:ktor-client-core:$version"
         const val android = "io.ktor:ktor-client-android:$version"
         const val ios = "io.ktor:ktor-client-ios:$version"
 
         // Features https://ktor.io/docs/http-client-features.html
-        const val serialization = "io.ktor:ktor-client-serialization:$version"
+        const val serialization = "io.ktor:ktor-serialization-kotlinx-json:$version"
+        const val contentNegotiation = "io.ktor:ktor-client-content-negotiation:$version"
     }
 
     object Matee {

--- a/buildSrc/src/main/kotlin/extensions/Property.kt
+++ b/buildSrc/src/main/kotlin/extensions/Property.kt
@@ -10,6 +10,9 @@ fun getStringProperty(project: Project, propertyArg: String, defaultValue: Strin
 fun getIntegerProperty(project: Project, propertyArg: String, defaultValue: Int) =
     project.getPropertyValue(propertyArg, defaultValue).toInt()
 
+fun getBooleanProperty(project: Project, propertyArg: String, defaultValue: Boolean) =
+    project.getPropertyValue(propertyArg, defaultValue).toBoolean()
+
 private fun <T> Project.getPropertyValue(propertyArg: String, defaultValue: T): String {
     var value: String? = null
 

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Build KMP"
-               scriptText = "if [ -z &quot;$CI&quot; ]; then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;    scripts/build-kmp.sh&#10;fi&#10;">
+               scriptText = "if [ -z &quot;$CI&quot; ]; then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;    scripts/build-kmp.sh &quot;${CONFIGURATION}&quot; false&#10;fi&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Build KMP"
-               scriptText = "if [ -z &quot;$CI&quot; ]; then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;    scripts/build-kmp.sh&#10;fi&#10;">
+               scriptText = "if [ -z &quot;$CI&quot; ]; then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;    scripts/build-kmp.sh &quot;${CONFIGURATION}&quot; false&#10;fi&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Build KMP"
-               scriptText = "if [ -z &quot;$CI&quot; ]; then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;    scripts/build-kmp.sh&#10;fi&#10;">
+               scriptText = "if [ -z &quot;$CI&quot; ]; then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    exec &gt; prebuild-kmp.log 2&gt;&amp;1 # For debugging&#10;    scripts/build-kmp.sh &quot;${CONFIGURATION}&quot; false&#10;fi&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/scripts/build-kmp.sh
+++ b/ios/scripts/build-kmp.sh
@@ -1,4 +1,18 @@
 #!/bin/zsh -l
 
+# First argument  - XCODE_CONFIGURATION : DEBUG/RELEASE
+# Second argument - ARM64_ONLY : true/false
+# Script with no arguments use default values - XCODE_CONFIGURATION: RELEASE, ARM64_ONLY: false
+# Sample:
+#       ./scripts/build-kmp.sh                -> optimised release build with arm64, x64, simulator
+#       ./scripts/build-kmp.sh release true   -> optimised release build with only arm64
+#       ./scripts/build-kmp.sh release false  -> optimised release build with arm64, x64, simulator
+#       ./scripts/build-kmp.sh debug true     -> debug build with only arm64
+#       ./scripts/build-kmp.sh debug false    -> debug build with arm64, x64, simulator
+
 cd ..
-./gradlew buildXCFramework -PXCODE_CONFIGURATION=${CONFIGURATION}
+
+configuration=$1
+arm64only=$2
+
+./gradlew :shared:buildXCFramework -PXCODE_CONFIGURATION=${configuration} -PARM64_ONLY=${arm64only} && ./gradlew :shared:copyXCFramework -PXCODE_CONFIGURATION=${configuration} -PARM64_ONLY=${arm64only}

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -47,6 +47,9 @@ kotlin {
                 implementation(Dependency.Ktor.core)
                 implementation(Dependency.Ktor.serialization)
                 implementation(Dependency.Ktor.contentNegotiation)
+                implementation(Dependency.Ktor.logging)
+
+                implementation(Dependency.Kermit.core)
             }
         }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -19,16 +19,16 @@ android {
 kotlin {
     android()
 
-
     val xcf = XCFramework(Project.iosShared)
-    listOf(iosX64(), iosArm64(), iosSimulatorArm64())
-        .forEach {
-            it.binaries.framework {
+    KmmConfig.getSupportedPlatforms(this, project).forEach {
+        it.binaries.framework {
+            if (this.buildType == KmmConfig.getCurrentNativeBuildType(project)) {
                 baseName = Project.iosShared
                 isStatic = false
                 xcf.add(this)
             }
         }
+    }
 
     sourceSets {
         val commonMain by getting {
@@ -46,6 +46,7 @@ kotlin {
 
                 implementation(Dependency.Ktor.core)
                 implementation(Dependency.Ktor.serialization)
+                implementation(Dependency.Ktor.contentNegotiation)
             }
         }
 
@@ -99,9 +100,11 @@ sqldelight {
     }
 }
 
+tasks.register("buildXCFramework") {
+    dependsOn("assemble${Project.iosShared}XCFramework")
+}
 
-tasks.create("buildXCFramework") {
-    dependsOn("assembleDevstackKmpSharedXCFramework")
+tasks.register("copyXCFramework") {
     copyXCFramework(Project.iosShared)
 }
 

--- a/shared/src/commonMain/kotlin/cz/matee/devstack/kmp/shared/base/error/util/Network.kt
+++ b/shared/src/commonMain/kotlin/cz/matee/devstack/kmp/shared/base/error/util/Network.kt
@@ -5,7 +5,7 @@ import cz.matee.devstack.kmp.shared.base.error.domain.AuthError
 import cz.matee.devstack.kmp.shared.base.error.domain.BackendError
 import cz.matee.devstack.kmp.shared.base.error.domain.CommonError
 import cz.matee.devstack.kmp.shared.infrastructure.remote.AuthPaths
-import io.ktor.client.features.*
+import io.ktor.client.plugins.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 

--- a/shared/src/commonMain/kotlin/cz/matee/devstack/kmp/shared/base/util/helpers/ResultTo.kt
+++ b/shared/src/commonMain/kotlin/cz/matee/devstack/kmp/shared/base/util/helpers/ResultTo.kt
@@ -2,11 +2,18 @@ package cz.matee.devstack.kmp.shared.base.util.helpers
 
 import cz.matee.devstack.kmp.shared.base.ErrorResult
 import cz.matee.devstack.kmp.shared.base.Result
+import io.ktor.client.call.*
+import io.ktor.client.statement.*
 
-// TODO refactor to sealed interface
-sealed class ResultType
-object Success : ResultType()
-class Error(val error: ErrorResult) : ResultType()
+sealed interface ResultType
+object Success : ResultType
+class Error(val error: ErrorResult) : ResultType
+
+suspend inline infix fun <reified T : Any> HttpResponse.resultsTo(result: ResultType): Result<T> =
+    when (result) {
+        Success -> Result.Success(body<T>())
+        is Error -> Result.Error(result.error, null)
+    }
 
 infix fun <T : Any> T.resultsTo(result: ResultType): Result<T> =
     when (result) {

--- a/shared/src/commonMain/kotlin/cz/matee/devstack/kmp/shared/infrastructure/remote/AuthService.kt
+++ b/shared/src/commonMain/kotlin/cz/matee/devstack/kmp/shared/infrastructure/remote/AuthService.kt
@@ -22,18 +22,16 @@ internal class AuthService(private val client: HttpClient) {
 
     suspend fun login(body: LoginRequest): Result<LoginDto> =
         runCatchingAuthNetworkExceptions {
-            client.post<LoginDto>(
-                path = AuthPaths.login,
-                body = body
-            ) resultsTo Success
+            client.post(AuthPaths.login) {
+                setBody(body)
+            } resultsTo Success
         }
 
 
     suspend fun register(body: RegistrationRequest): Result<RegistrationDto> =
         runCatchingAuthNetworkExceptions {
-            client.post<RegistrationDto>(
-                path = AuthPaths.registration,
-                body = body
-            ) resultsTo Success
+            client.post(AuthPaths.registration) {
+                setBody(body)
+            } resultsTo Success
         }
 }

--- a/shared/src/commonMain/kotlin/cz/matee/devstack/kmp/shared/infrastructure/remote/AuthService.kt
+++ b/shared/src/commonMain/kotlin/cz/matee/devstack/kmp/shared/infrastructure/remote/AuthService.kt
@@ -12,7 +12,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.*
 
 internal object AuthPaths {
-    private const val root = "/auth"
+    private const val root = "/api/auth"
     const val login = "$root/login"
     const val registration = "$root/registration"
 }

--- a/shared/src/commonMain/kotlin/cz/matee/devstack/kmp/shared/infrastructure/remote/UserService.kt
+++ b/shared/src/commonMain/kotlin/cz/matee/devstack/kmp/shared/infrastructure/remote/UserService.kt
@@ -1,5 +1,6 @@
 package cz.matee.devstack.kmp.shared.infrastructure.remote
 
+import cz.matee.devstack.kmp.shared.base.Result
 import cz.matee.devstack.kmp.shared.base.error.util.runCatchingCommonNetworkExceptions
 import cz.matee.devstack.kmp.shared.base.util.helpers.Success
 import cz.matee.devstack.kmp.shared.base.util.helpers.resultsTo
@@ -18,32 +19,37 @@ internal object UserPaths {
 
 internal class UserService(private val client: HttpClient) {
 
-    suspend fun getUsers(page: Int, limit: Int) = runCatchingCommonNetworkExceptions {
-        client.get<UserPagingDto>(path = UserPaths.users) {
-            url {
-                parameters["page"] = page.toString()
-                parameters["limit"] = limit.toString()
-            }
-        } resultsTo Success
+    suspend fun getUsers(
+        page: Int,
+        limit: Int
+    ): Result<UserPagingDto> {
+        return runCatchingCommonNetworkExceptions {
+            client.get(UserPaths.users) {
+                url {
+                    parameters["page"] = page.toString()
+                    parameters["limit"] = limit.toString()
+                }
+            } resultsTo Success
+        }
     }
 
-    suspend fun getUserById(userId: String) = runCatchingCommonNetworkExceptions {
-        client.get<UserDto>(path = UserPaths.user(userId)) resultsTo Success
+    suspend fun getUserById(userId: String): Result<UserDto> {
+        return runCatchingCommonNetworkExceptions {
+            client.get(UserPaths.user(userId)) resultsTo Success
+        }
     }
 
-    @OptIn(ExperimentalStdlibApi::class)
-    suspend fun updateUser(userId: String, body: UserUpdateRequest) =
-        runCatchingCommonNetworkExceptions {
-            client.put<UserDto>(
-                path = UserPaths.user(userId),
-                body = buildMap<String, String> {
+    suspend fun updateUser(userId: String, body: UserUpdateRequest): Result<UserDto> {
+        return runCatchingCommonNetworkExceptions {
+            client.put(UserPaths.user(userId)) {
+                setBody(buildMap {
                     body.pass?.also { put(UserUpdateRequest::pass.name, it) }
                     body.firstName?.also { put(UserUpdateRequest::firstName.name, it) }
                     body.lastName?.also { put(UserUpdateRequest::lastName.name, it) }
                     body.bio?.also { put(UserUpdateRequest::bio.name, it) }
                     body.phone?.also { put(UserUpdateRequest::phone.name, it) }
-                }
-            ) resultsTo Success
+                })
+            } resultsTo Success
         }
-
+    }
 }

--- a/shared/src/commonMain/kotlin/cz/matee/devstack/kmp/shared/infrastructure/remote/UserService.kt
+++ b/shared/src/commonMain/kotlin/cz/matee/devstack/kmp/shared/infrastructure/remote/UserService.kt
@@ -11,7 +11,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.*
 
 internal object UserPaths {
-    private const val root = "/user"
+    private const val root = "/api/user"
     const val users = root
     fun user(id: String) = "$root/$id"
 }


### PR DESCRIPTION
# :pencil: Description
- This PR adds optimisations for KMM build 🚀 

# :bulb: What’s new?
- Until now we were building all valid architectures for both debug and release configurations during KMM build. That is unnecessary, as we don't always need all of the architectures/configurations. For example when uploading to the AppStore Connect we need only arm64/release etc.
- This PR adds two arguments to `build-kmp.sh` - `XCODE_CONFIGURATION` and `ARM64_ONLY`. 
- When we are running the script from Xcode's pre-build phases we want to pass the current build configuration (which [is available](https://stackoverflow.com/questions/54733776/detect-debug-or-release-for-custom-configuration-with-run-script) as `${CONFIGURATION}`) in order to build only debug or release. It would be nice to also build only the target architecture for device/simulator, however I wasn't able to retrieve that information during pre-build phase. So for now we are building all valid architectures by passing false to `ARM64_ONLY`.
- During develop and release builds on the CI we need only arm64/release and we can achieve exactly that by passing `release true`. 🙌 For test builds on the CI we need all architecture in debug configuration so we pass `debug false`.
- Also we don't need to define `CI` env variable in our workflows, as [it is already available](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables) as a default env variable.

# :no_mouth: What’s missing?
- KMM part - done ✅

# :books: References
- https://xcodebuildsettings.com/#archs
- https://stackoverflow.com/questions/3007215/xcode-iphone-how-to-detect-simulator-target-at-compile-time
