### PR TITLE
Use SwiftGen via SPM Plugin

### DIFF
--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack.xcscheme
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Generate code"
-               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild.log 2&gt;&amp;1 # For debugging&#10;scripts/twine.sh&#10;scripts/swiftgen.sh&#10;scripts/sourcery.sh&#10;scripts/apollo.sh&#10;">
+               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild.log 2&gt;&amp;1 # For debugging&#10;scripts/twine.sh&#10;scripts/sourcery.sh&#10;scripts/apollo.sh&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha.xcscheme
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Generate code"
-               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild.log 2&gt;&amp;1 # For debugging&#10;scripts/twine.sh&#10;scripts/swiftgen.sh&#10;scripts/sourcery.sh&#10;scripts/apollo.sh&#10;">
+               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild.log 2&gt;&amp;1 # For debugging&#10;scripts/twine.sh&#10;scripts/sourcery.sh&#10;scripts/apollo.sh&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta.xcscheme
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Generate code"
-               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild.log 2&gt;&amp;1 # For debugging&#10;scripts/twine.sh&#10;scripts/swiftgen.sh&#10;scripts/sourcery.sh&#10;scripts/apollo.sh&#10;">
+               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild.log 2&gt;&amp;1 # For debugging&#10;scripts/twine.sh&#10;scripts/sourcery.sh&#10;scripts/apollo.sh&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/DevStack.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/DevStack.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -170,6 +170,15 @@
         "revision" : "7e2c5f3cbbeea68e004915e3a8961e20bd11d824",
         "version" : "1.18.0"
       }
+    },
+    {
+      "identity" : "swiftgenplugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftGen/SwiftGenPlugin",
+      "state" : {
+        "revision" : "879b85a470cacd70c19e22eb7e11a3aed66f4068",
+        "version" : "6.6.2"
+      }
     }
   ],
   "version" : 2

--- a/ios/Mintfile
+++ b/ios/Mintfile
@@ -1,3 +1,2 @@
-SwiftGen/SwiftGen@6.5.1
 realm/SwiftLint@0.46.5
 krzysztofzablocki/Sourcery@1.8.0

--- a/ios/PresentationLayer/UIToolkit/Package.swift
+++ b/ios/PresentationLayer/UIToolkit/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "Utilities", path: "../DomainLayer/Utilities")
+        .package(name: "Utilities", path: "../DomainLayer/Utilities"),
+        .package(url: "https://github.com/SwiftGen/SwiftGenPlugin", .upToNextMajor(from: "6.6.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -26,6 +27,14 @@ let package = Package(
             name: "UIToolkit",
             dependencies: [
                 .product(name: "Utilities", package: "Utilities")
+            ],
+            exclude: [
+                "swiftgen-strings.stencil",
+                "swiftgen-xcassets.stencil",
+                "swiftgen.yml"
+            ],
+            plugins: [
+              .plugin(name: "SwiftGenPlugin", package: "SwiftGenPlugin")
             ]
         )
     ]

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/swiftgen-strings.stencil
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/swiftgen-strings.stencil
@@ -1,7 +1,10 @@
 // Template is based on the default strings/flat-swift5.stencil
-// It is modified to use snake_case instead of camelCase in order to make it more handy in a combination with twine
-// This is done by changing `swiftIdentifier:"pretty"` to `swiftIdentifier`
 // https://github.com/SwiftGen/SwiftGen/blob/stable/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
+
+// Modifications:
+// - Use `.myModule` [workaround](https://developer.apple.com/forums/thread/664295) to address SwiftUI Previews crashes
+// - Use snake_case instead of camelCase, this is done by changing `swiftIdentifier:"pretty"` to `swiftIdentifier`
+// - Ability to change localization via Environment.localization
 
 // swiftlint:disable all
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/swiftgen-xcassets.stencil
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/swiftgen-xcassets.stencil
@@ -1,5 +1,8 @@
-// Template is just a clone of the default xcassets/swift5.stencil (to make it work with Mint)
+// Template is based on the default xcassets/swift5.stencil
 // https://github.com/SwiftGen/SwiftGen/blob/stable/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
+
+// Modifications:
+// - Use `.myModule` [workaround](https://developer.apple.com/forums/thread/664295) to address SwiftUI Previews crashes
 
 // swiftlint:disable all
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/swiftgen.yml
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/swiftgen.yml
@@ -1,0 +1,21 @@
+input_dir: Resources
+output_dir: ${DERIVED_SOURCES_DIR}
+
+strings:
+  inputs:
+    - Localizable/Base.lproj/Localizable.strings
+  outputs:
+    - templatePath: swiftgen-strings.stencil
+      output: Localizable.generated.swift
+      params:
+        publicAccess: true
+
+xcassets:
+  inputs:
+    - Colors.xcassets
+    - Images.xcassets
+  outputs:
+    - templatePath: swiftgen-xcassets.stencil
+      output: Assets.generated.swift
+      params:
+        publicAccess: true

--- a/ios/scripts/swiftgen.sh
+++ b/ios/scripts/swiftgen.sh
@@ -1,7 +1,0 @@
-#!/bin/zsh -l
-
-echo "Generating identifiers for Colors and Images"
-mint run swiftgen run xcassets "PresentationLayer/UIToolkit/Sources/UIToolkit/Resources/Colors.xcassets" "PresentationLayer/UIToolkit/Sources/UIToolkit/Resources/Images.xcassets" -p "scripts/swiftgen-xcassets.stencil" --param publicAccess --output "PresentationLayer/UIToolkit/Sources/UIToolkit/Resources/Constants/Assets.generated.swift"
-
-echo "Generating identifiers for Localizable"
-mint run swiftgen run strings "PresentationLayer/UIToolkit/Sources/UIToolkit/Resources/Localizable/Base.lproj/Localizable.strings" -p "scripts/swiftgen-strings.stencil" --param publicAccess --output "PresentationLayer/UIToolkit/Sources/UIToolkit/Resources/Constants/Localizable.generated.swift"


### PR DESCRIPTION
# :pencil: Description
- This PR integrates SwiftGen via SPM Plugin instead of Mint 🚀 

# :bulb: What’s new?
- SwiftGen recently released support for SPM Plugins, so we can start using it instead of Mint + pre-build script.

# :no_mouth: What’s missing?
- Use Sourcery via SPM - https://github.com/krzysztofzablocki/Sourcery/issues/1023
- Use SwiftLint via SPM - https://github.com/realm/SwiftLint/issues/3840
- Use Apollo via SPM - https://github.com/apollographql/iOSCodegenTemplate/issues/14

# :books: References
- https://github.com/SwiftGen/SwiftGenPlugin
- https://github.com/SwiftGen/SwiftGen/blob/stable/Documentation/ConfigFile.md
