### PR TITLE
Use @Persisted property wrapper in DBUser

### DIFF
--- a/ios/DataLayer/Toolkits/UserToolkit/Sources/UserToolkit/DatabaseModels/DBUser.swift
+++ b/ios/DataLayer/Toolkits/UserToolkit/Sources/UserToolkit/DatabaseModels/DBUser.swift
@@ -6,19 +6,15 @@
 import RealmSwift
 import SharedDomain
 
-@objcMembers final class DBUser: Object {
-    dynamic var id: String = ""
-    dynamic var email: String = ""
-    dynamic var firstName: String = ""
-    dynamic var lastName: String = ""
-    dynamic var phone: String = ""
-    dynamic var bio: String = ""
-    dynamic var pictureUrl: String = ""
-    dynamic var counter: Int = 0
-
-    override static func primaryKey() -> String? {
-        "id"
-    }
+final class DBUser: Object {
+    @Persisted(primaryKey: true) var id: String = ""
+    @Persisted var email: String = ""
+    @Persisted var firstName: String = ""
+    @Persisted var lastName: String = ""
+    @Persisted var phone: String = ""
+    @Persisted var bio: String = ""
+    @Persisted var pictureUrl: String = ""
+    @Persisted var counter: Int = 0
     
     override var apiModel: [String: Any] {
         var model = super.apiModel

--- a/ios/DevStack.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/DevStack.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/abseil-cpp-SwiftPM.git",
       "state" : {
-        "revision" : "fffc3c2729be5747390ad02d5100291a0d9ad26a",
-        "version" : "0.20200225.4"
+        "revision" : "583de9bd60f66b40e78d08599cc92036c2e7e4e1",
+        "version" : "0.20220203.2"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios",
       "state" : {
-        "revision" : "08a41bad4ebf76ae8e4efebf26862a42084b7786",
-        "version" : "0.51.2"
+        "revision" : "42646f765d22dac0f22bfff48590102195c76da4",
+        "version" : "0.53.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ProxymanApp/atlantis",
       "state" : {
-        "revision" : "b60ef22babc5cc8997841b378bb2993229fac9eb",
-        "version" : "1.16.0"
+        "revision" : "2b26bf7fe2c5751335dca015b9e77514210d28d4",
+        "version" : "1.18.2"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
       "state" : {
-        "revision" : "734a8247442fde37df4364c21f6a0085b6a36728",
-        "version" : "0.7.2"
+        "revision" : "dd3eda2b05a3f459fc3073695ad1b28659066eab",
+        "version" : "0.9.1"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "78f7087fd5d48eb7c36e299f330b6dddccd647b2",
-        "version" : "8.12.1"
+        "revision" : "111d8d6ad1a1afd6c8e9561d26e55ab1e74fcb42",
+        "version" : "8.15.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "6cc2991c11872510a5314bc112cc7558dd9d046a",
-        "version" : "8.12.0"
+        "revision" : "ef819db8c58657a6ca367322e73f3b6322afe0a2",
+        "version" : "8.15.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "15ccdfd25ac55b9239b82809531ff26605e7556e",
-        "version" : "9.1.2"
+        "revision" : "5056b15c5acbb90cd214fe4d6138bdf5a740e5a8",
+        "version" : "9.2.0"
       }
     },
     {
@@ -68,17 +68,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "b3bb0c5551fb3f80ca939829639ab5b093edd14f",
-        "version" : "7.7.0"
+        "revision" : "f4abe56ce62a779e64b525eb133c8fc2a84bbc1f",
+        "version" : "7.7.1"
       }
     },
     {
-      "identity" : "grpc-swiftpm",
+      "identity" : "grpc-ios",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/grpc-SwiftPM.git",
+      "location" : "https://github.com/grpc/grpc-ios.git",
       "state" : {
-        "revision" : "fb405dd2c7901485f7e158b24e3a0a47e4efd8b5",
-        "version" : "1.28.4"
+        "revision" : "8440b914756e0d26d4f4d054a1c1581daedfc5b6",
+        "version" : "1.44.3-grpc"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "bc6a19702ac76ac4e488b68148710eb815f9bc56",
-        "version" : "1.7.0"
+        "revision" : "4e9bbf2808b8fee444e84a48f5f3c12641987d3e",
+        "version" : "1.7.2"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "611337c330350c9c1823ad6d671e7f936af5ee13",
-        "version" : "2.0.0"
+        "revision" : "3e4e743631e86c8c70dbc6efdc7beaa6e90fd3bb",
+        "version" : "2.1.1"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-cocoa.git",
       "state" : {
-        "revision" : "11ef7d31e3f3668c7434c5fd129a85ca52740b24",
-        "version" : "10.24.1"
+        "revision" : "5629961d905387b40fb2e1e9d8594c87a2ab8811",
+        "version" : "10.28.6"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-core",
       "state" : {
-        "revision" : "e9eec444d13ebebc062202407e79b9833428a24e",
-        "version" : "11.11.0"
+        "revision" : "6f6a0f415bd33cf2ced4467e36a47f7c84f0a1d7",
+        "version" : "12.5.1"
       }
     },
     {
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "7e2c5f3cbbeea68e004915e3a8961e20bd11d824",
-        "version" : "1.18.0"
+        "revision" : "b8230909dedc640294d7324d37f4c91ad3dcf177",
+        "version" : "1.20.1"
       }
     },
     {

--- a/ios/README.md
+++ b/ios/README.md
@@ -2,7 +2,7 @@
 - Historical development prior monorepo can be seen in the [devstack-ios-app](https://github.com/MateeDevs/devstack-ios-app) repo
 
 ## Documents
-- **API Doc:** [Postmanerator](https://devstack-server-production.up.railway.app/apidoc.html)
+- **APIDoc:** [Postmanerator](https://devstack-server-production.up.railway.app/apidoc.html)
 - **Specification:** FIXME
 - **Graphics:** FIXME
 - **Assets**: FIXME


### PR DESCRIPTION
# :pencil: Description
- This PR updates dependencies and uses `@Persisted` property wrapper in DBUser

# :bulb: What’s new?
- Realm added a new [`@Persisted` property wrapper](https://www.mongodb.com/docs/realm/sdk/swift/model-data/define-model/supported-types/#property-cheat-sheet) in 10.10.0 so we don't have to use `@objc dynamic` anymore
- Optional types can now be defined just as `@Persisted var value: Bool?` instead of using `RealmOptional<Bool?>()`
- Primary key can be marked with `@Persisted(primaryKey: true)` instead of `override static func primaryKey()`
- Also if you need to generate an unique id it can be achieved with `@Persisted(primaryKey: true) var _id: ObjectId`

# :no_mouth: What’s missing?
- Nothing

# :books: References
- https://www.mongodb.com/docs/realm/sdk/swift/model-data/define-model/supported-types/#property-cheat-sheet
