### PR TITLE
Fix SwiftGen Plugin high CPU usage issue

### DIFF
--- a/ios/DevStack.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/DevStack.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -170,15 +170,6 @@
         "revision" : "b8230909dedc640294d7324d37f4c91ad3dcf177",
         "version" : "1.20.1"
       }
-    },
-    {
-      "identity" : "swiftgenplugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SwiftGen/SwiftGenPlugin",
-      "state" : {
-        "revision" : "879b85a470cacd70c19e22eb7e11a3aed66f4068",
-        "version" : "6.6.2"
-      }
     }
   ],
   "version" : 2

--- a/ios/PresentationLayer/UIToolkit/Package.swift
+++ b/ios/PresentationLayer/UIToolkit/Package.swift
@@ -17,8 +17,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "Utilities", path: "../DomainLayer/Utilities"),
-        .package(url: "https://github.com/SwiftGen/SwiftGenPlugin", .upToNextMajor(from: "6.6.0"))
+        .package(name: "Utilities", path: "../DomainLayer/Utilities")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -34,8 +33,20 @@ let package = Package(
                 "swiftgen.yml"
             ],
             plugins: [
-              .plugin(name: "SwiftGenPlugin", package: "SwiftGenPlugin")
+                .plugin(name: "SwiftGenPlugin")
             ]
+        ),
+        .plugin(
+            name: "SwiftGenPlugin",
+            capability: .buildTool(),
+            dependencies: [
+                .target(name: "swiftgen")
+            ]
+        ),
+        .binaryTarget(
+            name: "swiftgen",
+            url: "https://github.com/SwiftGen/SwiftGen/releases/download/6.6.2/swiftgen-6.6.2.artifactbundle.zip",
+            checksum: "7586363e24edcf18c2da3ef90f379e9559c1453f48ef5e8fbc0b818fbbc3a045"
         )
     ]
 )

--- a/ios/PresentationLayer/UIToolkit/Plugins/SwiftGenPlugin/Plugin.swift
+++ b/ios/PresentationLayer/UIToolkit/Plugins/SwiftGenPlugin/Plugin.swift
@@ -1,0 +1,34 @@
+//
+//  Created by Petr Chmelar on 08.09.2022
+//  Copyright © 2022 Matee. All rights reserved.
+//
+
+import PackagePlugin
+
+@main
+struct SwiftGenPlugins: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+        let configurations: [Path] = [context.package.directory, target.directory]
+            .map { $0.appending("swiftgen.yml") }
+        
+        return try configurations.map { configuration in
+            return Command.prebuildCommand(
+                displayName: "SwiftGen",
+                executable: try context.tool(named: "swiftgen").path,
+                arguments: [
+                    "config",
+                    "run",
+                    "--verbose",
+                    "--config", "\(configuration)"
+                ],
+                environment: [
+                    "PROJECT_DIR": context.package.directory,
+                    "TARGET_NAME": target.name,
+                    "PRODUCT_MODULE_NAME": (target as? SourceModuleTarget)?.moduleName ?? "",
+                    "DERIVED_SOURCES_DIR": context.pluginWorkDirectory
+                ],
+                outputFilesDirectory: context.pluginWorkDirectory
+            )
+        }
+    }
+}


### PR DESCRIPTION
# :pencil: Description
- This PR fixes an issue with high CPU usage when using Swift Plugins

# :bulb: What’s new?
- We recently started using SwiftGen via SPM Plugin - https://github.com/MateeDevs/devstack-native-app/pull/42
- Apparently, Apple fucks up this function, resulting in high CPU usage and unusable Xcode 🙃 
- Temporary solution is to use the plugin locally instead of having it as a remote dependency

# :no_mouth: What’s missing?
- Change back to remote dependency once Apple fixes this issue

# :books: References
- https://github.com/SwiftGen/SwiftGenPlugin/issues/2
- https://forums.swift.org/t/spm-plugin-with-binary-target-high-cpu-usage/59535
- https://github.com/DroidKaigi/conference-app-2022/pull/88
