### PR TITLE
CI: rm plist_path, dynamic api_key_path

### DIFF
--- a/.github/workflows/ios-develop.yml
+++ b/.github/workflows/ios-develop.yml
@@ -18,8 +18,6 @@ jobs:
         continue-on-error: true
         with:
           clean: false
-      - name: Pull Twine repo
-        run: git -C $TWINE_FOLDER pull origin master
       - name: Setup tools
         working-directory: ios
         run: ./scripts/setup.sh
@@ -32,7 +30,7 @@ jobs:
         env:
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_MATEE }}
         working-directory: ios
-        run: echo "$APP_STORE_CONNECT_API_KEY_CONTENT" > AuthKey.p8
+        run: echo "$APP_STORE_CONNECT_API_KEY_CONTENT" > AuthKey_Matee.p8
       - name: Create a new Alpha build
         working-directory: ios
         run: fastlane build_alpha

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -13,8 +13,6 @@ jobs:
         continue-on-error: true
         with:
           clean: false
-      - name: Pull Twine repo
-        run: git -C $TWINE_FOLDER pull origin master
       - name: Setup tools
         working-directory: ios
         run: ./scripts/setup.sh
@@ -27,7 +25,7 @@ jobs:
         env:
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_MATEE }}
         working-directory: ios
-        run: echo "$APP_STORE_CONNECT_API_KEY_CONTENT" > AuthKey.p8
+        run: echo "$APP_STORE_CONNECT_API_KEY_CONTENT" > AuthKey_Matee.p8
       - name: Create builds
         working-directory: ios
         run: |

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -16,8 +16,6 @@ jobs:
         continue-on-error: true
         with:
           clean: false
-      - name: Pull Twine repo
-        run: git -C $TWINE_FOLDER pull origin master
       - name: Setup tools
         working-directory: ios
         run: ./scripts/setup.sh
@@ -25,7 +23,5 @@ jobs:
         working-directory: ios
         run: ./scripts/build-kmp.sh
       - name: Run tests
-        env:
-          CI: ${{ true }}
         working-directory: ios
         run: fastlane test_alpha

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -15,7 +15,6 @@ alpha = {
   output_name: "A-DevStack",
   app_identifier: "cz.matee.devstack.alpha",
   scheme: "DevStack_Alpha",
-  info_plist_path: "./Application/Info/Info+Proxyman.plist",
   testflight_groups: ['App Store Connect Users', 'Public'],
   testflight_link: "NOT AVAILABLE"
 }
@@ -24,7 +23,6 @@ beta = {
   output_name: "B-DevStack",
   app_identifier: "cz.matee.devstack.beta",
   scheme: "DevStack_Beta",
-  info_plist_path: "./Application/Info/Info+Proxyman.plist",
   testflight_groups: ['App Store Connect Users', 'Public'],
   testflight_link: "https://testflight.apple.com/join/aff9SFVc"
 }
@@ -33,7 +31,6 @@ production = {
   output_name: "DevStack",
   app_identifier: "cz.matee.devstack",
   scheme: "DevStack",
-  info_plist_path: "./Application/Info/Info.plist",
   testflight_groups: ['App Store Connect Users', 'Public'],
   testflight_link: "https://testflight.apple.com/join/lP4bFs1a"
 }
@@ -45,6 +42,7 @@ production = {
 matee = {
   api_key_id: "CQT3ZM53U8",
   api_key_issuer_id: "e85e5ea1-4316-4e79-a474-858ab98197e0",
+  api_key_path: File.expand_path('../AuthKey_Matee.p8'),
   certificate_path: "signing/Development_Matee.p12"
 }
 
@@ -62,6 +60,7 @@ testflight_contact = {
 client = {
   api_key_id: matee[:api_key_id],
   api_key_issuer_id: matee[:api_key_issuer_id],
+  api_key_path: matee[:api_key_path],
   certificate_path: matee[:certificate_path]
 }
 
@@ -94,7 +93,7 @@ platform :ios do
     unless ENV["BUILD_NUMBER"] =~ /^\d{1,18}$/
       UI.user_error!("Invalid build number: \"#{ENV["BUILD_NUMBER"]}\". Expect 1-18 digits")
     end
-    set_info_plist_value(path: config[:info_plist_path], key: "CFBundleVersion", value: ENV["BUILD_NUMBER"])
+    increment_build_number(build_number: ENV["BUILD_NUMBER"])
 
     keychain_password = SecureRandom.base64
     delete_keychain(name: "fastlane") if File.exist?(File.expand_path("~/Library/Keychains/fastlane-db"))
@@ -118,7 +117,7 @@ platform :ios do
       archive_path: "#{config[:output_name]}.xcarchive",
       output_directory: "./ipa",
       output_name: config[:output_name],
-      xcargs: "-allowProvisioningUpdates -authenticationKeyID #{config[:api_key_id]} -authenticationKeyIssuerID #{config[:api_key_issuer_id]} -authenticationKeyPath #{File.expand_path('../AuthKey.p8')}"
+      xcargs: "-allowProvisioningUpdates -authenticationKeyID #{config[:api_key_id]} -authenticationKeyIssuerID #{config[:api_key_issuer_id]} -authenticationKeyPath #{config[:api_key_path]}"
     )
   end
 


### PR DESCRIPTION
# :pencil: Description
- This PR adds minor CI improvements 🤓 

# :bulb: What’s new?
- `info_plist_path` deleted, we can just use `increment_build_number`
- `api_key_path` added - it's useful when we need different API keys for alpha/beta and release
- No need to pull Twine repo, as `strings.txt` is already part of the monorepo

# :no_mouth: What’s missing?
- Nothing

# :books: References
- https://docs.fastlane.tools/actions/increment_build_number/
- https://docs.fastlane.tools/app-store-connect-api/
