### PR TITLE
Filter possible configuration locations of the SwiftGenPlugin

### DIFF
--- a/ios/PresentationLayer/UIToolkit/Plugins/SwiftGenPlugin/Plugin.swift
+++ b/ios/PresentationLayer/UIToolkit/Plugins/SwiftGenPlugin/Plugin.swift
@@ -3,6 +3,7 @@
 //  Copyright © 2022 Matee. All rights reserved.
 //
 
+import Foundation
 import PackagePlugin
 
 @main

--- a/ios/PresentationLayer/UIToolkit/Plugins/SwiftGenPlugin/Plugin.swift
+++ b/ios/PresentationLayer/UIToolkit/Plugins/SwiftGenPlugin/Plugin.swift
@@ -10,6 +10,7 @@ struct SwiftGenPlugins: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
         let configurations: [Path] = [context.package.directory, target.directory]
             .map { $0.appending("swiftgen.yml") }
+            .filter { FileManager.default.fileExists(atPath: $0.string) }
         
         return try configurations.map { configuration in
             return Command.prebuildCommand(


### PR DESCRIPTION
Because there is only one configuration, you need to filter its possible locations.
