### PR TITLE
Fix warnings

### DIFF
--- a/ios/DataLayer/Toolkits/AnalyticsToolkit/.swiftpm/xcode/xcshareddata/xcschemes/AnalyticsToolkit.xcscheme
+++ b/ios/DataLayer/Toolkits/AnalyticsToolkit/.swiftpm/xcode/xcshareddata/xcschemes/AnalyticsToolkit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/DataLayer/Toolkits/AuthToolkit/.swiftpm/xcode/xcshareddata/xcschemes/AuthToolkit.xcscheme
+++ b/ios/DataLayer/Toolkits/AuthToolkit/.swiftpm/xcode/xcshareddata/xcschemes/AuthToolkit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/DataLayer/Toolkits/LocationToolkit/.swiftpm/xcode/xcshareddata/xcschemes/LocationToolkit.xcscheme
+++ b/ios/DataLayer/Toolkits/LocationToolkit/.swiftpm/xcode/xcshareddata/xcschemes/LocationToolkit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/DataLayer/Toolkits/PushNotificationsToolkit/.swiftpm/xcode/xcshareddata/xcschemes/PushNotificationsToolkit.xcscheme
+++ b/ios/DataLayer/Toolkits/PushNotificationsToolkit/.swiftpm/xcode/xcshareddata/xcschemes/PushNotificationsToolkit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/DataLayer/Toolkits/RemoteConfigToolkit/.swiftpm/xcode/xcshareddata/xcschemes/RemoteConfigToolkit.xcscheme
+++ b/ios/DataLayer/Toolkits/RemoteConfigToolkit/.swiftpm/xcode/xcshareddata/xcschemes/RemoteConfigToolkit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/DataLayer/Toolkits/RocketToolkit/.swiftpm/xcode/xcshareddata/xcschemes/RocketToolkit.xcscheme
+++ b/ios/DataLayer/Toolkits/RocketToolkit/.swiftpm/xcode/xcshareddata/xcschemes/RocketToolkit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/DataLayer/Toolkits/UserToolkit/.swiftpm/xcode/xcshareddata/xcschemes/UserToolkit.xcscheme
+++ b/ios/DataLayer/Toolkits/UserToolkit/.swiftpm/xcode/xcshareddata/xcschemes/UserToolkit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/DevStack.xcodeproj/project.pbxproj
+++ b/ios/DevStack.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -60,7 +60,7 @@
 		45DEBE1C27A153A10075C7E2 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45DEBE1B27A153A10075C7E2 /* SwiftUI.framework */; };
 		45DEBE1F27A153A10075C7E2 /* Widget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DEBE1E27A153A10075C7E2 /* Widget.swift */; };
 		45DEBE2127A153A20075C7E2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 45DEBE2027A153A20075C7E2 /* Assets.xcassets */; };
-		45DEBE2527A153A20075C7E2 /* DevStack Widget.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 45DEBE1827A153A10075C7E2 /* DevStack Widget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		45DEBE2527A153A20075C7E2 /* DevStack Widget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 45DEBE1827A153A10075C7E2 /* DevStack Widget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,15 +74,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		45DEBE2627A153A20075C7E2 /* Embed App Extensions */ = {
+		45DEBE2627A153A20075C7E2 /* Embed Foundation Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
-				45DEBE2527A153A20075C7E2 /* DevStack Widget.appex in Embed App Extensions */,
+				45DEBE2527A153A20075C7E2 /* DevStack Widget.appex in Embed Foundation Extensions */,
 			);
-			name = "Embed App Extensions";
+			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -403,7 +403,7 @@
 				4558D30420FCC8FF005BC325 /* Frameworks */,
 				4558D30520FCC8FF005BC325 /* Resources */,
 				453D3FCD25ED976A0094ADD7 /* Copy GoogleService-Info.plist */,
-				45DEBE2627A153A20075C7E2 /* Embed App Extensions */,
+				45DEBE2627A153A20075C7E2 /* Embed Foundation Extensions */,
 				4564A9F7289CFF3D00A0FEF0 /* Upload dSYMs to Crashlytics */,
 			);
 			buildRules = (
@@ -478,7 +478,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1310;
+				LastUpgradeCheck = 1400;
 				ORGANIZATIONNAME = Matee;
 				TargetAttributes = {
 					4558D30620FCC8FF005BC325 = {
@@ -540,6 +540,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		0C3E096223F6B3950051287D /* Script for SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -558,6 +559,7 @@
 		};
 		453D3FCD25ED976A0094ADD7 /* Copy GoogleService-Info.plist */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -576,6 +578,7 @@
 		};
 		4564A9F7289CFF3D00A0FEF0 /* Upload dSYMs to Crashlytics */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack Widget.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack Widget.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1400"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1400"
    version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha Widget.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha Widget.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1400"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1400"
    version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta Widget.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta Widget.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1400"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1400"
    version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/DomainLayer/SharedDomain/.swiftpm/xcode/xcshareddata/xcschemes/SharedDomain.xcscheme
+++ b/ios/DomainLayer/SharedDomain/.swiftpm/xcode/xcshareddata/xcschemes/SharedDomain.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/DomainLayer/SharedDomain/Package.swift
+++ b/ios/DomainLayer/SharedDomain/Package.swift
@@ -33,6 +33,9 @@ let package = Package(
             name: "SharedDomain",
             dependencies: [
                 "DevstackKmpShared"
+            ],
+            linkerSettings: [
+                .unsafeFlags(["-Xlinker", "-no_application_extension"])
             ]
         ),
         .target(

--- a/ios/DomainLayer/Utilities/.swiftpm/xcode/xcshareddata/xcschemes/Utilities.xcscheme
+++ b/ios/DomainLayer/Utilities/.swiftpm/xcode/xcshareddata/xcschemes/Utilities.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/PresentationLayer/Onboarding/.swiftpm/xcode/xcshareddata/xcschemes/Onboarding.xcscheme
+++ b/ios/PresentationLayer/Onboarding/.swiftpm/xcode/xcshareddata/xcschemes/Onboarding.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/PresentationLayer/Profile/.swiftpm/xcode/xcshareddata/xcschemes/Profile.xcscheme
+++ b/ios/PresentationLayer/Profile/.swiftpm/xcode/xcshareddata/xcschemes/Profile.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/PresentationLayer/Recipes/.swiftpm/xcode/xcshareddata/xcschemes/Recipes.xcscheme
+++ b/ios/PresentationLayer/Recipes/.swiftpm/xcode/xcshareddata/xcschemes/Recipes.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/PresentationLayer/UIToolkit/.swiftpm/xcode/xcshareddata/xcschemes/UIToolkit.xcscheme
+++ b/ios/PresentationLayer/UIToolkit/.swiftpm/xcode/xcshareddata/xcschemes/UIToolkit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/PresentationLayer/Users/.swiftpm/xcode/xcshareddata/xcschemes/Users.xcscheme
+++ b/ios/PresentationLayer/Users/.swiftpm/xcode/xcshareddata/xcschemes/Users.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
# :pencil: Description
- This PR fixes various warnings

# :bulb: What’s new?
- Project and schemes upgraded for Xcode 14
- Warning `linking against dylib not safe for use in application extensions` from Widget is now [suppressed by adding `linkerSettings`](https://danielsaidi.com/blog/2022/05/18/how-to-suppress-linking-warning) to the `SharedDomain/Package.swift`
- Xcode 14 introduces a new warning for Run Script build phases: `Run script build phase 'XYZ' will be run during every build because it does not specify any outputs`. It affects `Script for SwiftLint` / `Copy GoogleService-Info.plist` / `Upload dSYMs to Crashlytics` and can be suppressed by checking `Based on dependency analysis` checkbox. In case of SwiftLint it would be nice to run it based on changed inputs once [it is ready](https://github.com/realm/SwiftLint/issues/4015).
- You can also experience `~/Library/org.swift.swiftpm/collections.json has been deprecated` warning. This warning is a local one and can be [suppressed by deleting that file](https://stackoverflow.com/questions/71266281/xcode-13-3-beta-3-swift-package-init-shows-warning-library-org-swift-swif).

# :no_mouth: What’s missing?
- There are also some new warnings `Result of call to 'XYZ' is unused` in Xcode 14. However, it [seems like a bug](https://stackoverflow.com/questions/73199596/xcode-14-beta-4-warnings-about-unused-return-values-even-when-using-discardab) in Swift / Xcode 14.

# :books: References
- In text
