### PR TITLE
Update SwiftLint to 0.50.3 and use via SPM Plugins

### DIFF
--- a/ios/DevStack.xcodeproj/project.pbxproj
+++ b/ios/DevStack.xcodeproj/project.pbxproj
@@ -395,7 +395,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4558D31920FCC900005BC325 /* Build configuration list for PBXNativeTarget "DevStack" */;
 			buildPhases = (
-				0C3E096223F6B3950051287D /* Script for SwiftLint */,
 				4558D30320FCC8FF005BC325 /* Sources */,
 				4558D30420FCC8FF005BC325 /* Frameworks */,
 				4558D30520FCC8FF005BC325 /* Resources */,
@@ -406,6 +405,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				457CD0E42991606B00F491F9 /* PBXTargetDependency */,
 				45DEBE2427A153A20075C7E2 /* PBXTargetDependency */,
 			);
 			name = DevStack;
@@ -500,6 +500,7 @@
 			packageReferences = (
 				459EF41025BF6EEF00C9DAC0 /* XCRemoteSwiftPackageReference "atlantis" */,
 				45A0EBB027ADFA210005A01E /* XCRemoteSwiftPackageReference "Resolver" */,
+				457CD0E22991603400F491F9 /* XCRemoteSwiftPackageReference "SwiftLint" */,
 			);
 			productRefGroup = 4558D30820FCC8FF005BC325 /* Products */;
 			projectDirPath = "";
@@ -534,25 +535,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0C3E096223F6B3950051287D /* Script for SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Script for SwiftLint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ $ENABLE_PREVIEWS == \"NO\" ]\nthen\n    scripts/swiftlint.sh\nfi\n";
-		};
 		453D3FCD25ED976A0094ADD7 /* Copy GoogleService-Info.plist */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -624,6 +606,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		457CD0E42991606B00F491F9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 457CD0E32991606B00F491F9 /* SwiftLintPlugin */;
+		};
 		45DEBE2427A153A20075C7E2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 45DEBE1727A153A10075C7E2 /* DevStack Widget */;
@@ -1448,6 +1434,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		457CD0E22991603400F491F9 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/SwiftLint";
+			requirement = {
+				kind = revision;
+				revision = aba0f63704a666317c2456f7be93aa90d2f14113;
+			};
+		};
 		459EF41025BF6EEF00C9DAC0 /* XCRemoteSwiftPackageReference "atlantis" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ProxymanApp/atlantis";
@@ -1590,6 +1584,11 @@
 		45702E6128422A2A008D5487 /* NetworkProvider */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = NetworkProvider;
+		};
+		457CD0E32991606B00F491F9 /* SwiftLintPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 457CD0E22991603400F491F9 /* XCRemoteSwiftPackageReference "SwiftLint" */;
+			productName = "plugin:SwiftLintPlugin";
 		};
 		459C3706274B001B00536110 /* Atlantis */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ios/DevStack.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/DevStack.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -46,6 +46,15 @@
       }
     },
     {
+      "identity" : "collectionconcurrencykit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+      "state" : {
+        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+        "version" : "0.2.0"
+      }
+    },
+    {
       "identity" : "commander",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kylef/Commander.git",
@@ -217,6 +226,15 @@
       }
     },
     {
+      "identity" : "sourcekitten",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "state" : {
+        "revision" : "f403b5cdbaa1748fe74da47915013fe058166e03",
+        "version" : "0.34.0"
+      }
+    },
+    {
       "identity" : "sourcery",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzysztofzablocki/Sourcery.git",
@@ -265,8 +283,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
-        "version" : "1.1.4"
+        "revision" : "4ad606ba5d7673ea60679a61ff867cc1ff8c8e86",
+        "version" : "1.2.1"
       }
     },
     {
@@ -303,6 +321,32 @@
       "state" : {
         "revision" : "879b85a470cacd70c19e22eb7e11a3aed66f4068",
         "version" : "6.6.2"
+      }
+    },
+    {
+      "identity" : "swiftlint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/SwiftLint",
+      "state" : {
+        "revision" : "aba0f63704a666317c2456f7be93aa90d2f14113"
+      }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "4d0f62f561458cbe1f732171e625f03195151b60",
+        "version" : "7.0.1"
       }
     },
     {

--- a/ios/Mintfile
+++ b/ios/Mintfile
@@ -1,1 +1,0 @@
-realm/SwiftLint@0.46.5

--- a/ios/scripts/setup.sh
+++ b/ios/scripts/setup.sh
@@ -20,15 +20,6 @@ echo "⚙️  Downloading GraphQL schemas and generating code from queries"
 echo "⚙️  Generating mocks for UseCases and Repositories"
 ./sourcery.sh
 
-echo "⚙️  Checking whether Homebrew is installed"
-if command -v brew &> /dev/null; then
-  echo "✅ Homebrew is installed"
-else
-  echo "❌ Homebrew is not installed"
-  echo "Please visit https://brew.sh for more info"
-  exit
-fi
-
 echo "⚙️  Checking whether Twine is installed"
 if command -v twine &> /dev/null; then
   echo "✅ Twine is installed"
@@ -36,15 +27,3 @@ else
   echo "❌ Twine is not installed - installing now"
   gem install twine
 fi
-
-echo "⚙️  Checking whether Mint is installed"
-if command -v mint &> /dev/null; then
-  echo "✅ Mint is installed"
-else
-  echo "❌ Mint is not installed - installing now"
-  brew install mint
-fi
-
-echo "⚙️  Bootstraping Mint dependencies"
-cd ..
-mint bootstrap

--- a/ios/scripts/swiftlint-analyze.sh
+++ b/ios/scripts/swiftlint-analyze.sh
@@ -7,4 +7,4 @@ echo "Building project in order to obtain xcodebuild.log"
 xcodebuild -workspace DevStack.xcworkspace -scheme DevStack_Alpha > xcodebuild.log
 
 echo "Running SwiftLint Static Analyzer"
-mint run swiftlint analyze --config .swiftlint.yml --compiler-log-path xcodebuild.log
+swiftlint analyze --config .swiftlint.yml --compiler-log-path xcodebuild.log

--- a/ios/scripts/swiftlint.sh
+++ b/ios/scripts/swiftlint.sh
@@ -1,5 +1,0 @@
-#!/bin/zsh -l
-
-echo "Running SwiftLint"
-mint run swiftlint autocorrect --config .swiftlint.yml
-mint run swiftlint --config .swiftlint.yml


### PR DESCRIPTION
# :pencil: Description
- This PR updates SwiftLint to 0.50.0 and changes the usage to SPM Plugins 🚀  

# :bulb: What’s new?
- SwiftLint recently [released version 0.50.0](https://github.com/realm/SwiftLint/releases/tag/0.50.0-rc.1) with support for SPM Plugins - check [documentation](https://github.com/realm/SwiftLint#plug-in-support) for more info. 👀
- SwiftLint is now added as a Package Dependency directly to the DevStack project, and its plugin is executed on every build via Build Phases.

<img width="1512" alt="Screenshot 2022-10-09 at 22 34 28" src="https://user-images.githubusercontent.com/3842139/194780777-909c0aad-a0f3-4492-8b1b-571bd2a0ee52.png">

# :no_mouth: What’s missing?
- For now, we have to point to the exact commit of SwiftLint, because it is using an exact commit of SwiftSyntax internally and Xcode is throwing an error.
- Also for now we can't use both Sourcery (other [PR](https://github.com/MateeDevs/devstack-native-app/pull/52)) and SwiftLint via SPM Plugins. Both are using an exact commit of SwiftSyntax internally, but those commits are different, and Xcode is throwing an error.
- Both issues mentioned above should be resolved soon, then we can merge both PRs and get rid of Mint completely. 🎉 

# :books: References
- In text
- https://github.com/realm/SwiftLint/issues/4326
- https://forums.swift.org/t/telling-xcode-14-beta-4-to-trust-build-tool-plugins-programatically/59305/5