### PR TITLE
Fix schemaName in Apollo config

### DIFF
--- a/ios/.swiftlint.yml
+++ b/ios/.swiftlint.yml
@@ -2,7 +2,7 @@ excluded:
   - Carthage
   - Pods
   - vendor
-  - DataLayer/Toolkits/RocketToolkit/.build
+  - DataLayer/Providers/GraphQLProvider/.build
   - DataLayer/Toolkits/RocketToolkit/Sources/RocketToolkit/NetworkModels/Apollo
   - DataLayer/Toolkits/RocketToolkit/Sources/RocketToolkitMocks
   

--- a/ios/DataLayer/Providers/GraphQLProvider/Package.resolved
+++ b/ios/DataLayer/Providers/GraphQLProvider/Package.resolved
@@ -1,0 +1,50 @@
+{
+  "pins" : [
+    {
+      "identity" : "apollo-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apollographql/apollo-ios",
+      "state" : {
+        "revision" : "29d42fb5b17a2c1823ec0750af8e628067e43b4c",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "inflectorkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/InflectorKit",
+      "state" : {
+        "revision" : "d8cbcc04972690aaa5fc760a2b9ddb3e9f0decd7",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "sqlite.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stephencelis/SQLite.swift.git",
+      "state" : {
+        "revision" : "4d543d811ee644fa4cc4bfa0be996b4dd6ba0f54",
+        "version" : "0.13.3"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
+        "version" : "1.0.3"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ios/DataLayer/Toolkits/AnalyticsToolkit/Package.swift
+++ b/ios/DataLayer/Toolkits/AnalyticsToolkit/Package.swift
@@ -16,9 +16,9 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "Utilities", path: "../../DomainLayer/Utilities"),
-        .package(name: "SharedDomain", path: "../../DomainLayer/SharedDomain"),
-        .package(name: "AnalyticsProvider", path: "../Providers/AnalyticsProvider")
+        .package(name: "Utilities", path: "../../../DomainLayer/Utilities"),
+        .package(name: "SharedDomain", path: "../../../DomainLayer/SharedDomain"),
+        .package(name: "AnalyticsProvider", path: "../../Providers/AnalyticsProvider")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/ios/DataLayer/Toolkits/AuthToolkit/Package.swift
+++ b/ios/DataLayer/Toolkits/AuthToolkit/Package.swift
@@ -16,11 +16,11 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "Utilities", path: "../../DomainLayer/Utilities"),
-        .package(name: "SharedDomain", path: "../../DomainLayer/SharedDomain"),
-        .package(name: "DatabaseProvider", path: "../Providers/DatabaseProvider"),
-        .package(name: "KeychainProvider", path: "../Providers/KeychainProvider"),
-        .package(name: "NetworkProvider", path: "../Providers/NetworkProvider")
+        .package(name: "Utilities", path: "../../../DomainLayer/Utilities"),
+        .package(name: "SharedDomain", path: "../../../DomainLayer/SharedDomain"),
+        .package(name: "DatabaseProvider", path: "../../Providers/DatabaseProvider"),
+        .package(name: "KeychainProvider", path: "../../Providers/KeychainProvider"),
+        .package(name: "NetworkProvider", path: "../../Providers/NetworkProvider")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/ios/DataLayer/Toolkits/LocationToolkit/Package.swift
+++ b/ios/DataLayer/Toolkits/LocationToolkit/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "SharedDomain", path: "../../DomainLayer/SharedDomain"),
-        .package(name: "LocationProvider", path: "../Providers/LocationProvider")
+        .package(name: "SharedDomain", path: "../../../DomainLayer/SharedDomain"),
+        .package(name: "LocationProvider", path: "../../Providers/LocationProvider")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/ios/DataLayer/Toolkits/PushNotificationsToolkit/Package.swift
+++ b/ios/DataLayer/Toolkits/PushNotificationsToolkit/Package.swift
@@ -16,9 +16,9 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "Utilities", path: "../../DomainLayer/Utilities"),
-        .package(name: "SharedDomain", path: "../../DomainLayer/SharedDomain"),
-        .package(name: "PushNotificationsProvider", path: "../Providers/PushNotificationsProvider")
+        .package(name: "Utilities", path: "../../../DomainLayer/Utilities"),
+        .package(name: "SharedDomain", path: "../../../DomainLayer/SharedDomain"),
+        .package(name: "PushNotificationsProvider", path: "../../Providers/PushNotificationsProvider")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/ios/DataLayer/Toolkits/RemoteConfigToolkit/Package.swift
+++ b/ios/DataLayer/Toolkits/RemoteConfigToolkit/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "SharedDomain", path: "../../DomainLayer/SharedDomain"),
-        .package(name: "RemoteConfigProvider", path: "../Providers/RemoteConfigProvider")
+        .package(name: "SharedDomain", path: "../../../DomainLayer/SharedDomain"),
+        .package(name: "RemoteConfigProvider", path: "../../Providers/RemoteConfigProvider")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/ios/DataLayer/Toolkits/RocketToolkit/Package.swift
+++ b/ios/DataLayer/Toolkits/RocketToolkit/Package.swift
@@ -5,10 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "RocketToolkit",
-    platforms: [
-        .iOS(.v14),
-        .macOS(.v10_14)
-    ],
+    platforms: [.iOS(.v14)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/ios/DataLayer/Toolkits/RocketToolkit/apollo-codegen-config.json
+++ b/ios/DataLayer/Toolkits/RocketToolkit/apollo-codegen-config.json
@@ -13,7 +13,7 @@
     },
     "downloadTimeout": 60,
     "headers": [],
-    "outputPath": "./schema.graphqls"
+    "outputPath": "../../Toolkits/RocketToolkit/schema.graphqls"
   },
   "input": {
     "operationSearchPaths": [

--- a/ios/DataLayer/Toolkits/RocketToolkit/apollo-codegen-config.json
+++ b/ios/DataLayer/Toolkits/RocketToolkit/apollo-codegen-config.json
@@ -1,5 +1,5 @@
 {
-  "schemaName": "rocket",
+  "schemaName": "Rocket",
   "schemaDownloadConfiguration": {
     "downloadMethod": {
       "introspection": {
@@ -40,5 +40,8 @@
         "path": "./Sources/RocketToolkitMocks"
       }
     }
+  },
+  "options": {
+      "pruneGeneratedFiles": false
   }
 }

--- a/ios/DataLayer/Toolkits/UserToolkit/Package.swift
+++ b/ios/DataLayer/Toolkits/UserToolkit/Package.swift
@@ -16,10 +16,10 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "Utilities", path: "../../DomainLayer/Utilities"),
-        .package(name: "SharedDomain", path: "../../DomainLayer/SharedDomain"),
-        .package(name: "DatabaseProvider", path: "../Providers/DatabaseProvider"),
-        .package(name: "NetworkProvider", path: "../Providers/NetworkProvider")
+        .package(name: "Utilities", path: "../../../DomainLayer/Utilities"),
+        .package(name: "SharedDomain", path: "../../../DomainLayer/SharedDomain"),
+        .package(name: "DatabaseProvider", path: "../../Providers/DatabaseProvider"),
+        .package(name: "NetworkProvider", path: "../../Providers/NetworkProvider")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/ios/DomainLayer/SharedDomain/Package.swift
+++ b/ios/DomainLayer/SharedDomain/Package.swift
@@ -5,10 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "SharedDomain",
-    platforms: [
-        .iOS(.v14),
-        .macOS(.v10_14)
-    ],
+    platforms: [.iOS(.v14)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/ios/PresentationLayer/Onboarding/Package.swift
+++ b/ios/PresentationLayer/Onboarding/Package.swift
@@ -16,9 +16,9 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "UIToolkit", path: "./UIToolkit"),
-        .package(name: "Utilities", path: "../DomainLayer/Utilities"),
-        .package(name: "SharedDomain", path: "../DomainLayer/SharedDomain"),
+        .package(name: "UIToolkit", path: "../UIToolkit"),
+        .package(name: "Utilities", path: "../../DomainLayer/Utilities"),
+        .package(name: "SharedDomain", path: "../../DomainLayer/SharedDomain"),
         .package(url: "https://github.com/hmlongco/Resolver.git", .upToNextMajor(from: "1.0.0"))
     ],
     targets: [

--- a/ios/PresentationLayer/Profile/Package.swift
+++ b/ios/PresentationLayer/Profile/Package.swift
@@ -16,9 +16,9 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "UIToolkit", path: "./UIToolkit"),
-        .package(name: "Utilities", path: "../DomainLayer/Utilities"),
-        .package(name: "SharedDomain", path: "../DomainLayer/SharedDomain"),
+        .package(name: "UIToolkit", path: "../UIToolkit"),
+        .package(name: "Utilities", path: "../../DomainLayer/Utilities"),
+        .package(name: "SharedDomain", path: "../../DomainLayer/SharedDomain"),
         .package(url: "https://github.com/hmlongco/Resolver.git", .upToNextMajor(from: "1.0.0"))
     ],
     targets: [

--- a/ios/PresentationLayer/Recipes/Package.swift
+++ b/ios/PresentationLayer/Recipes/Package.swift
@@ -16,9 +16,9 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "UIToolkit", path: "./UIToolkit"),
-        .package(name: "Utilities", path: "../DomainLayer/Utilities"),
-        .package(name: "SharedDomain", path: "../DomainLayer/SharedDomain"),
+        .package(name: "UIToolkit", path: "../UIToolkit"),
+        .package(name: "Utilities", path: "../../DomainLayer/Utilities"),
+        .package(name: "SharedDomain", path: "../../DomainLayer/SharedDomain"),
         .package(url: "https://github.com/hmlongco/Resolver.git", .upToNextMajor(from: "1.0.0"))
     ],
     targets: [

--- a/ios/PresentationLayer/UIToolkit/Package.swift
+++ b/ios/PresentationLayer/UIToolkit/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "Utilities", path: "../DomainLayer/Utilities")
+        .package(name: "Utilities", path: "../../DomainLayer/Utilities")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/ios/PresentationLayer/Users/Package.swift
+++ b/ios/PresentationLayer/Users/Package.swift
@@ -16,9 +16,9 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "UIToolkit", path: "./UIToolkit"),
-        .package(name: "Utilities", path: "../DomainLayer/Utilities"),
-        .package(name: "SharedDomain", path: "../DomainLayer/SharedDomain"),
+        .package(name: "UIToolkit", path: "../UIToolkit"),
+        .package(name: "Utilities", path: "../../DomainLayer/Utilities"),
+        .package(name: "SharedDomain", path: "../../DomainLayer/SharedDomain"),
         .package(url: "https://github.com/hmlongco/Resolver.git", .upToNextMajor(from: "1.0.0"))
     ],
     targets: [

--- a/ios/scripts/apollo.sh
+++ b/ios/scripts/apollo.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 cd "$(dirname "$0")"
+cd ../DataLayer/Providers/GraphQLProvider
 
-# RocketToolkit
-cd ../DataLayer/Toolkits/RocketToolkit
-swift package --disable-sandbox --allow-writing-to-package-directory apollo-fetch-schema
-swift package --disable-sandbox --allow-writing-to-package-directory apollo-generate
-cd ../../..
+echo "⚙️  RocketToolkit - Downloading GraphQL schema and generating code from queries"
+swift package --disable-sandbox --allow-writing-to-package-directory apollo-fetch-schema --path "../../Toolkits/RocketToolkit/apollo-codegen-config.json"
+swift package --disable-sandbox --allow-writing-to-package-directory apollo-generate --path "../../Toolkits/RocketToolkit/apollo-codegen-config.json"

--- a/ios/scripts/apollo.sh
+++ b/ios/scripts/apollo.sh
@@ -6,5 +6,4 @@ cd "$(dirname "$0")"
 cd ../DataLayer/Toolkits/RocketToolkit
 swift package --disable-sandbox --allow-writing-to-package-directory apollo-fetch-schema
 swift package --disable-sandbox --allow-writing-to-package-directory apollo-generate
-find ./Sources/RocketToolkitMocks -type f -exec sed -i '' -e "s/rocket/Rocket/g" {} +
 cd ../../..


### PR DESCRIPTION
# :pencil: Description
- This PR fixes `schemaName` issue in the Apollo config

# :bulb: What’s new?
- As mentioned in https://github.com/MateeDevs/devstack-native-app/pull/51, there was a problem with `schemaName` in the Apollo config file.
- Turns out that it can be resolved by adding `"pruneGeneratedFiles": false` to the config. 💪 

# :no_mouth: What’s missing?
- Nothing

# :books: References
- https://github.com/apollographql/apollo-ios/issues/2546
