### PR TITLE
Update Apollo

### DIFF
--- a/ios/DataLayer/Toolkits/RocketToolkit/apollo-codegen-config.json
+++ b/ios/DataLayer/Toolkits/RocketToolkit/apollo-codegen-config.json
@@ -40,8 +40,5 @@
         "path": "./Sources/RocketToolkitMocks"
       }
     }
-  },
-  "options": {
-      "pruneGeneratedFiles": false
   }
 }

--- a/ios/DevStack.xcworkspace/contents.xcworkspacedata
+++ b/ios/DevStack.xcworkspace/contents.xcworkspacedata
@@ -4,6 +4,416 @@
    <FileRef
       location = "group:README.md">
    </FileRef>
+   <Group
+      location = "container:"
+      name = "Kotlin">
+      <Group
+         location = "group:../shared/src/commonMain"
+         name = "commonMain">
+         <Group
+            location = "group:kotlin"
+            name = "kotlin">
+            <Group
+               location = "group:cz"
+               name = "cz">
+               <Group
+                  location = "group:matee"
+                  name = "matee">
+                  <Group
+                     location = "group:devstack"
+                     name = "devstack">
+                     <Group
+                        location = "group:kmp"
+                        name = "kmp">
+                        <Group
+                           location = "group:shared"
+                           name = "shared">
+                           <Group
+                              location = "group:di"
+                              name = "di">
+                              <FileRef
+                                 location = "group:Module.kt">
+                              </FileRef>
+                           </Group>
+                           <Group
+                              location = "group:util"
+                              name = "util">
+                              <Group
+                                 location = "group:extension"
+                                 name = "extension">
+                                 <FileRef
+                                    location = "group:Book.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:UserPaging.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:User.kt">
+                                 </FileRef>
+                              </Group>
+                           </Group>
+                           <Group
+                              location = "group:system"
+                              name = "system">
+                              <FileRef
+                                 location = "group:Config.kt">
+                              </FileRef>
+                              <FileRef
+                                 location = "group:Logger.kt">
+                              </FileRef>
+                           </Group>
+                           <Group
+                              location = "group:infrastructure"
+                              name = "infrastructure">
+                              <Group
+                                 location = "group:source"
+                                 name = "source">
+                                 <FileRef
+                                    location = "group:UserRemoteSourceImpl.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:BookLocalSourceImpl.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:AuthSourceImpl.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:UserLocalSourceImpl.kt">
+                                 </FileRef>
+                              </Group>
+                              <Group
+                                 location = "group:local"
+                                 name = "local">
+                                 <FileRef
+                                    location = "group:AuthDao.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:Database.kt">
+                                 </FileRef>
+                              </Group>
+                              <Group
+                                 location = "group:model"
+                                 name = "model">
+                                 <FileRef
+                                    location = "group:LoginDto.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:UserDto.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:RegistrationDto.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:UserPagingDto.kt">
+                                 </FileRef>
+                              </Group>
+                              <Group
+                                 location = "group:remote"
+                                 name = "remote">
+                                 <FileRef
+                                    location = "group:AuthService.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:HttpClient.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:UserService.kt">
+                                 </FileRef>
+                              </Group>
+                           </Group>
+                           <Group
+                              location = "group:data"
+                              name = "data">
+                              <Group
+                                 location = "group:repository"
+                                 name = "repository">
+                                 <FileRef
+                                    location = "group:AuthRepositoryImpl.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:BookRepositoryImpl.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:UserRepositoryImpl.kt">
+                                 </FileRef>
+                              </Group>
+                              <Group
+                                 location = "group:source"
+                                 name = "source">
+                                 <FileRef
+                                    location = "group:BookSource.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:UserSource.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:AuthSource.kt">
+                                 </FileRef>
+                              </Group>
+                           </Group>
+                           <Group
+                              location = "group:domain"
+                              name = "domain">
+                              <Group
+                                 location = "group:repository"
+                                 name = "repository">
+                                 <FileRef
+                                    location = "group:BookRepository.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:UserRepository.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:AuthRepository.kt">
+                                 </FileRef>
+                              </Group>
+                              <Group
+                                 location = "group:model"
+                                 name = "model">
+                                 <FileRef
+                                    location = "group:UserPagingResult.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:Book.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:User.kt">
+                                 </FileRef>
+                              </Group>
+                              <Group
+                                 location = "group:usecase"
+                                 name = "usecase">
+                                 <FileRef
+                                    location = "group:RegisterUseCaseImpl.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:DeleteAuthDataUseCaseImpl.kt">
+                                 </FileRef>
+                                 <Group
+                                    location = "group:user"
+                                    name = "user">
+                                    <FileRef
+                                       location = "group:UserCacheChangeFlowUseCaseImpl.kt">
+                                    </FileRef>
+                                    <FileRef
+                                       location = "group:GetUsersUseCaseImpl.kt">
+                                    </FileRef>
+                                    <FileRef
+                                       location = "group:GetUserUseCaseImpl.kt">
+                                    </FileRef>
+                                    <FileRef
+                                       location = "group:GetLocalUsersUseCaseImpl.kt">
+                                    </FileRef>
+                                    <FileRef
+                                       location = "group:ReplaceUserCacheWithUseCaseImpl.kt">
+                                    </FileRef>
+                                    <FileRef
+                                       location = "group:GetRemoteUsersUseCaseImpl.kt">
+                                    </FileRef>
+                                    <FileRef
+                                       location = "group:GetLoggedInUserUseCaseImpl.kt">
+                                    </FileRef>
+                                    <FileRef
+                                       location = "group:RefreshUsersUseCaseImpl.kt">
+                                    </FileRef>
+                                    <FileRef
+                                       location = "group:UpdateUserUseCaseImpl.kt">
+                                    </FileRef>
+                                    <FileRef
+                                       location = "group:UpdateLocalUserCacheUseCaseImpl.kt">
+                                    </FileRef>
+                                    <FileRef
+                                       location = "group:IsUserLoggedInUseCaseImpl.kt">
+                                    </FileRef>
+                                 </Group>
+                                 <Group
+                                    location = "group:book"
+                                    name = "book">
+                                    <FileRef
+                                       location = "group:GetBooksUseCaseImpl.kt">
+                                    </FileRef>
+                                    <FileRef
+                                       location = "group:RefreshBooksUseCaseImpl.kt">
+                                    </FileRef>
+                                 </Group>
+                                 <FileRef
+                                    location = "group:LoginUseCaseImpl.kt">
+                                 </FileRef>
+                              </Group>
+                           </Group>
+                           <Group
+                              location = "group:base"
+                              name = "base">
+                              <FileRef
+                                 location = "group:Result.kt">
+                              </FileRef>
+                              <Group
+                                 location = "group:util"
+                                 name = "util">
+                                 <Group
+                                    location = "group:extension"
+                                    name = "extension">
+                                    <FileRef
+                                       location = "group:Result.kt">
+                                    </FileRef>
+                                 </Group>
+                                 <Group
+                                    location = "group:helpers"
+                                    name = "helpers">
+                                    <FileRef
+                                       location = "group:ResultTo.kt">
+                                    </FileRef>
+                                 </Group>
+                              </Group>
+                              <Group
+                                 location = "group:usecase"
+                                 name = "usecase">
+                                 <FileRef
+                                    location = "group:UseCase.kt">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:UseCaseResult.kt">
+                                 </FileRef>
+                              </Group>
+                              <Group
+                                 location = "group:error"
+                                 name = "error">
+                                 <FileRef
+                                    location = "group:Messages.kt">
+                                 </FileRef>
+                                 <Group
+                                    location = "group:util"
+                                    name = "util">
+                                    <FileRef
+                                       location = "group:Network.kt">
+                                    </FileRef>
+                                 </Group>
+                                 <Group
+                                    location = "group:domain"
+                                    name = "domain">
+                                    <FileRef
+                                       location = "group:AuthError.kt">
+                                    </FileRef>
+                                    <FileRef
+                                       location = "group:CommonError.kt">
+                                    </FileRef>
+                                    <FileRef
+                                       location = "group:BackendError.kt">
+                                    </FileRef>
+                                 </Group>
+                              </Group>
+                           </Group>
+                        </Group>
+                     </Group>
+                  </Group>
+               </Group>
+            </Group>
+         </Group>
+         <Group
+            location = "group:sqldelight"
+            name = "sqldelight">
+            <Group
+               location = "group:cz"
+               name = "cz">
+               <Group
+                  location = "group:matee"
+                  name = "matee">
+                  <Group
+                     location = "group:devstack"
+                     name = "devstack">
+                     <Group
+                        location = "group:kmp"
+                        name = "kmp">
+                        <Group
+                           location = "group:shared"
+                           name = "shared">
+                           <Group
+                              location = "group:infrastructure"
+                              name = "infrastructure">
+                              <Group
+                                 location = "group:local"
+                                 name = "local">
+                                 <FileRef
+                                    location = "group:User.sq">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:Book.sq">
+                                 </FileRef>
+                                 <FileRef
+                                    location = "group:UserCache.sq">
+                                 </FileRef>
+                              </Group>
+                           </Group>
+                        </Group>
+                     </Group>
+                  </Group>
+               </Group>
+            </Group>
+         </Group>
+      </Group>
+      <Group
+         location = "group:../shared/src/iosMain"
+         name = "iosMain">
+         <Group
+            location = "group:kotlin"
+            name = "kotlin">
+            <Group
+               location = "group:cz"
+               name = "cz">
+               <Group
+                  location = "group:matee"
+                  name = "matee">
+                  <Group
+                     location = "group:devstack"
+                     name = "devstack">
+                     <Group
+                        location = "group:kmp"
+                        name = "kmp">
+                        <Group
+                           location = "group:shared"
+                           name = "shared">
+                           <Group
+                              location = "group:di"
+                              name = "di">
+                              <FileRef
+                                 location = "group:KoinIOS.kt">
+                              </FileRef>
+                           </Group>
+                           <FileRef
+                              location = "group:SwiftCoroutines.kt">
+                           </FileRef>
+                           <Group
+                              location = "group:system"
+                              name = "system">
+                              <FileRef
+                                 location = "group:Config.kt">
+                              </FileRef>
+                              <FileRef
+                                 location = "group:Logger.kt">
+                              </FileRef>
+                           </Group>
+                           <Group
+                              location = "group:infrastructure"
+                              name = "infrastructure">
+                              <Group
+                                 location = "group:local"
+                                 name = "local">
+                                 <FileRef
+                                    location = "group:Database.kt">
+                                 </FileRef>
+                              </Group>
+                           </Group>
+                           <FileRef
+                              location = "group:KotlinDateTime.kt">
+                           </FileRef>
+                        </Group>
+                     </Group>
+                  </Group>
+               </Group>
+            </Group>
+         </Group>
+      </Group>
+   </Group>
    <FileRef
       location = "group:DevStack.xcodeproj">
    </FileRef>

--- a/ios/DevStack.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/DevStack.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios",
       "state" : {
-        "revision" : "4b13a927b581c40d06f2c65f593f672a52c0c812",
-        "version" : "1.0.3"
+        "revision" : "e123b5fdbaaf926d98a6833f25cbdff51e22200b",
+        "version" : "1.0.6"
       }
     },
     {
@@ -176,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
-        "version" : "1.1.4"
+        "revision" : "fddd1c00396eed152c45a46bea9f47b98e59301d",
+        "version" : "1.2.0"
       }
     },
     {


### PR DESCRIPTION
# :pencil: Description
- This PR updates Apollo to 1.0.2

# :bulb: What’s new?
- Apollo recently released a new version 1.0.2 with a naming issue fix, so `pruneGeneratedFiles` is no longer needed

# :no_mouth: What’s missing?
- Nothing

# :books: References
- https://github.com/apollographql/apollo-ios/releases/tag/1.0.2
