### PR TITLE
Register for remote notifications in AppDelegate

### DIFF
--- a/ios/Application/AppDelegate.swift
+++ b/ios/Application/AppDelegate.swift
@@ -44,6 +44,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         // Setup firebase for debug
         firebaseDebugSetup()
         
+        // Register for remote notifications
+        application.registerForRemoteNotifications()
+        
         // Init main window with navigation controller
         let nc = BaseNavigationController(statusBarStyle: .lightContent)
         nc.navigationBar.isHidden = true


### PR DESCRIPTION
# :pencil: Description
- This PR improves registration for remote notifications

# :bulb: What’s new?
- Currently, we were calling [`registerForRemoteNotifications()`](https://developer.apple.com/documentation/uikit/uiapplication/1623078-registerforremotenotifications) in `FirebasePushNotificationsProvider` after a user allows push notifications. Although it usually works, there may be some scenarios where it can cause problems (after restoring the device from backup etc).
- So, to be on the safe side, it is better to call it also the recommended way - in `didFinishLaunchingWithOptions`. See references for more info.

# :no_mouth: What’s missing?
- Nothing

# :books: References
- https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns
- https://stackoverflow.com/questions/56628856/is-it-correct-to-call-registerforremotenotifications-all-the-time-app-starts
