### PR TITLE
Remove swift extensions for the use case interfaces that have been removed

### DIFF
--- a/ios/DomainLayer/SharedDomain/Package.resolved
+++ b/ios/DomainLayer/SharedDomain/Package.resolved
@@ -55,6 +55,15 @@
       }
     },
     {
+      "identity" : "semaphore",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/Semaphore",
+      "state" : {
+        "revision" : "f1c4a0acabeb591068dea6cffdd39660b86dec28",
+        "version" : "0.0.8"
+      }
+    },
+    {
       "identity" : "shellout",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/JohnSundell/ShellOut.git",

--- a/ios/DomainLayer/SharedDomain/Sources/SharedDomain/Common/Extensions/SharedUseCase+Extensions.swift
+++ b/ios/DomainLayer/SharedDomain/Sources/SharedDomain/Common/Extensions/SharedUseCase+Extensions.swift
@@ -50,55 +50,6 @@ public extension UseCaseFlowResult {
     }
 }
 
-public extension UseCase {
-    func execute<In: Any, Out>(params: In) async throws -> Out {
-        let jobWrapper: JobWrapper = JobWrapper()
-        return try await withTaskCancellationHandler(
-            operation: {
-                try await withCheckedThrowingContinuation { continuation in
-                    let coroutineJob = SwiftCoroutinesKt.subscribe(
-                        self,
-                        params: params,
-                        onSuccess: { data in
-                            let value: Out = data as! Out
-                            continuation.resume(returning: value)
-                            return
-                        }) { kotlinThrowable in
-                            continuation.resume(throwing: kotlinThrowable.asError())
-                    }
-                    jobWrapper.setJob(coroutineJob)
-                }
-            },
-            onCancel: {[jobWrapper] in
-                jobWrapper.job?.cancel(cause: nil)
-            }
-        )
-    }
-    
-    func execute<In: Any>(params: In) async throws {
-        let jobWrapper: JobWrapper = JobWrapper()
-        return try await withTaskCancellationHandler(
-            operation: {
-                try await withCheckedThrowingContinuation { continuation in
-                    let coroutineJob = SwiftCoroutinesKt.subscribe(
-                        self,
-                        params: params,
-                        onSuccess: { _ in
-                            continuation.resume()
-                            return
-                        }) { kotlinThrowable in
-                            continuation.resume(throwing: kotlinThrowable.asError())
-                    }
-                    jobWrapper.setJob(coroutineJob)
-                }
-            },
-            onCancel: {[jobWrapper] in
-                jobWrapper.job?.cancel(cause: nil)
-            }
-        )
-    }
-}
-
 public extension UseCaseResult {
     func execute<In: Any, Out>(params: In) async throws -> Out {
         let jobWrapper: JobWrapper = JobWrapper()
@@ -119,7 +70,7 @@ public extension UseCaseResult {
                             continuation.resume(returning: value)
                             return
                         },
-                        onThrow_: { kotlinThrowable in
+                        onThrow: { kotlinThrowable in
                             continuation.resume(throwing: kotlinThrowable.asError())
                         })
                     jobWrapper.setJob(coroutineJob)
@@ -149,57 +100,9 @@ public extension UseCaseResult {
                             continuation.resume()
                             return
                         },
-                        onThrow_: { kotlinThrowable in
+                        onThrow: { kotlinThrowable in
                             continuation.resume(throwing: kotlinThrowable.asError())
                         })
-                    jobWrapper.setJob(coroutineJob)
-                }
-            },
-            onCancel: {[jobWrapper] in
-                jobWrapper.job?.cancel(cause: nil)
-            }
-        )
-    }
-}
-
-public extension UseCaseNoParams {
-    func execute<Out>() async throws -> Out {
-        let jobWrapper: JobWrapper = JobWrapper()
-        return try await withTaskCancellationHandler(
-            operation: {
-                try await withCheckedThrowingContinuation { continuation in
-                    
-                    let coroutineJob = SwiftCoroutinesKt.subscribe(self) { data in
-                        let value: Out = data as! Out
-                        continuation.resume(returning: value)
-                        return
-                    } onThrow: { kotlinThrowable in
-                        continuation.resume(throwing: kotlinThrowable.asError())
-                    }
-                    
-                    jobWrapper.setJob(coroutineJob)
-                }
-            },
-            onCancel: {[jobWrapper] in
-                jobWrapper.job?.cancel(cause: nil)
-            }
-        )
-    }
-    
-    // Void returning UC
-    func execute() async throws {
-        let jobWrapper: JobWrapper = JobWrapper()
-        return try await withTaskCancellationHandler(
-            operation: {
-                try await withCheckedThrowingContinuation { continuation in
-                    
-                    let coroutineJob = SwiftCoroutinesKt.subscribe(self) { _ in
-                        continuation.resume()
-                        return
-                    }
-                onThrow: { kotlinThrowable in
-                    continuation.resume(throwing: kotlinThrowable.asError())
-                    }
                     jobWrapper.setJob(coroutineJob)
                 }
             },
@@ -229,7 +132,7 @@ public extension UseCaseResultNoParams {
                             continuation.resume(returning: value)
                             return
                         },
-                        onThrow_: { kotlinThrowable in
+                        onThrow: { kotlinThrowable in
                             continuation.resume(throwing: kotlinThrowable.asError())
                         })
                     jobWrapper.setJob(coroutineJob)
@@ -259,7 +162,7 @@ public extension UseCaseResultNoParams {
                             continuation.resume()
                             return
                         },
-                        onThrow_: { kotlinThrowable in
+                        onThrow: { kotlinThrowable in
                             continuation.resume(throwing: kotlinThrowable.asError())
                         })
                     jobWrapper.setJob(coroutineJob)


### PR DESCRIPTION
# :pencil: Description
- iOS build was crashing because of removed kotlin classes

# :bulb: What’s new?
- Removed extensions of UseCase and UseCaseNoParams
- Fixed parameter names after conflicting names are no longer an issue

# :no_mouth: What’s missing?
- Nothing

# :books: References
-
