### PR TITLE
Cache Images - native

### DIFF
--- a/ios/Application/AppDelegate.swift
+++ b/ios/Application/AppDelegate.swift
@@ -44,6 +44,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         // Setup firebase for debug
         firebaseDebugSetup()
         
+        // Setup Cache capacity
+        setupCacheCapacity()
+        
         // Register for remote notifications
         application.registerForRemoteNotifications()
         
@@ -131,6 +134,12 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
             args.append("-FIRAnalyticsDebugEnabled")
             ProcessInfo.processInfo.setValue(args, forKey: "arguments")
         }
+    }
+    
+    // MARK: Cache setup
+    private func setupCacheCapacity() {
+        URLCache.shared.memoryCapacity = 10_000_000 // ~10 MB memory space
+        URLCache.shared.diskCapacity = 1_000_000_000 // ~1GB disk cache space
     }
 }
 

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/Images/ImagesView.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/Images/ImagesView.swift
@@ -1,0 +1,41 @@
+//
+//  Created by David Kadlček on 12.05.2023
+//  Copyright © 2023 Matee. All rights reserved.
+//
+
+import SwiftUI
+import UIToolkit
+
+@available(iOS 15, *)
+struct ImagesView: View {
+    
+    @ObservedObject private var viewModel: ImagesViewModel
+
+    init(viewModel: ImagesViewModel) {
+        self.viewModel = viewModel
+    }
+    
+    var body: some View {
+        GeometryReader { geo in
+            ScrollView {
+                LazyVStack {
+                    ForEach(viewModel.state.urls, id: \.self) { url in
+                        RemoteImage(stringURL: url, defaultImage: Asset.Images.brandLogo.image)
+                            .frame(width: geo.size.width, height: geo.size.width)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+            
+        }
+    }
+}
+
+#if DEBUG
+@available(iOS 15, *)
+struct ImagesView_Previews: PreviewProvider {
+    static var previews: some View {
+        ImagesView(viewModel: ImagesViewModel(flowController: nil))
+    }
+}
+#endif

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/Images/ImagesView.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/Images/ImagesView.swift
@@ -27,6 +27,7 @@ struct ImagesView: View {
             }
             
         }
+        .lifecycle(viewModel)
     }
 }
 

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/Images/ImagesView.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/Images/ImagesView.swift
@@ -6,7 +6,6 @@
 import SwiftUI
 import UIToolkit
 
-@available(iOS 15, *)
 struct ImagesView: View {
     
     @ObservedObject private var viewModel: ImagesViewModel
@@ -32,7 +31,6 @@ struct ImagesView: View {
 }
 
 #if DEBUG
-@available(iOS 15, *)
 struct ImagesView_Previews: PreviewProvider {
     static var previews: some View {
         ImagesView(viewModel: ImagesViewModel(flowController: nil))

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/Images/ImagesView.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/Images/ImagesView.swift
@@ -19,7 +19,7 @@ struct ImagesView: View {
             ScrollView {
                 LazyVStack {
                     ForEach(viewModel.state.urls, id: \.self) { url in
-                        RemoteImage(stringURL: url, defaultImage: Asset.Images.brandLogo.image)
+                        RemoteImage(stringURL: url, placeholder: Asset.Images.brandLogo.image)
                             .frame(width: geo.size.width, height: geo.size.width)
                     }
                 }

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/Images/ImagesViewModel.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/Images/ImagesViewModel.swift
@@ -13,12 +13,6 @@ final class ImagesViewModel: BaseViewModel, ViewModel, ObservableObject {
     init(flowController: FlowController?) {
         self.flowController = flowController
         super.init()
-        setupCacheCapacity()
-    }
-    
-    private func setupCacheCapacity() {
-        URLCache.shared.memoryCapacity = 10_000_000 // ~10 MB memory space
-        URLCache.shared.diskCapacity = 1_000_000_000 // ~1GB disk cache space
     }
     
     // MARK: Lifecycle

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/Images/ImagesViewModel.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/Images/ImagesViewModel.swift
@@ -1,0 +1,62 @@
+//
+//  Created by David Kadlček on 12.05.2023
+//  Copyright © 2023 Matee. All rights reserved.
+//
+
+import Foundation
+import UIToolkit
+
+final class ImagesViewModel: BaseViewModel, ViewModel, ObservableObject {
+    // MARK: Dependencies
+    private weak var flowController: FlowController?
+
+    init(flowController: FlowController?) {
+        self.flowController = flowController
+        super.init()
+        setupCacheCapacity()
+    }
+    
+    private func setupCacheCapacity() {
+        URLCache.shared.memoryCapacity = 10_000_000 // ~10 MB memory space
+        URLCache.shared.diskCapacity = 1_000_000_000 // ~1GB disk cache space
+    }
+    
+    // MARK: Lifecycle
+    
+    override func onAppear() {
+        super.onAppear()
+    }
+    
+    // MARK: State
+    
+    @Published private(set) var state: State = State()
+
+    struct State {
+        var urls: [String] = [
+            "https://picsum.photos/id/1/300/300",
+            "https://picsum.photos/id/2/300/300",
+            "https://picsum.photos/id/3/300/300",
+            "https://picsum.photos/id/4/300/300",
+            "https://picsum.photos/id/5/300/300",
+            "https://picsum.photos/id/6/300/300",
+            "https://picsum.photos/id/7/300/300",
+            "https://picsum.photos/id/8/300/300",
+            "https://picsum.photos/id/9/300/300",
+            "https://picsum.photos/id/10/300/300",
+            "https://picsum.photos/id/11/300/300",
+            "https://picsum.photos/id/12/300/300",
+            "https://picsum.photos/id/13/300/300",
+            "https://picsum.photos/id/14/300/300",
+            "https://picsum.photos/id/15/300/300",
+            "https://picsum.photos/id/16/300/300"
+        ]
+    }
+    
+    // MARK: Intent
+    enum Intent {
+    }
+
+    func onIntent(_ intent: Intent) {}
+    
+    // MARK: Private
+}

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/Main/RecipesViewModel.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/Main/RecipesViewModel.swift
@@ -11,6 +11,7 @@ enum Recipe: String, CaseIterable {
     case books = "Books"
     case rocketLaunches = "RocketLaunches"
     case skeleton = "Skeleton"
+    case images = "Images"
 }
 
 final class RecipesViewModel: BaseViewModel, ViewModel, ObservableObject {
@@ -56,6 +57,8 @@ final class RecipesViewModel: BaseViewModel, ViewModel, ObservableObject {
             flowController?.handleFlow(RecipesFlow.recipes(.showRocketLaunches))
         case .skeleton:
             flowController?.handleFlow(RecipesFlow.recipes(.showSkeleton))
+        case .images:
+            flowController?.handleFlow(RecipesFlow.recipes(.showImages))
         }
     }
 }

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/RecipesFlowController.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/RecipesFlowController.swift
@@ -15,6 +15,7 @@ enum RecipesFlow: Flow, Equatable {
         case showBooks
         case showRocketLaunches
         case showSkeleton
+        case showImages
     }
 }
 
@@ -41,6 +42,7 @@ extension RecipesFlowController {
         case .showBooks: showBooks()
         case .showRocketLaunches: showRocketLaunches()
         case .showSkeleton: showSkeleton()
+        case .showImages: showImages()
         }
     }
     
@@ -66,5 +68,13 @@ extension RecipesFlowController {
         let vm = SkeletonViewModel(flowController: self)
         let vc = BaseHostingController(rootView: SkeletonView(viewModel: vm))
         navigationController.show(vc, sender: nil)
+    }
+    
+    private func showImages() {
+        if #available(iOS 15, *) {
+            let vm = ImagesViewModel(flowController: self)
+            let vc = BaseHostingController(rootView: ImagesView(viewModel: vm))
+            navigationController.show(vc, sender: nil)
+        }
     }
 }

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/RecipesFlowController.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/RecipesFlowController.swift
@@ -71,10 +71,8 @@ extension RecipesFlowController {
     }
     
     private func showImages() {
-        if #available(iOS 15, *) {
-            let vm = ImagesViewModel(flowController: self)
-            let vc = BaseHostingController(rootView: ImagesView(viewModel: vm))
-            navigationController.show(vc, sender: nil)
-        }
+        let vm = ImagesViewModel(flowController: self)
+        let vc = BaseHostingController(rootView: ImagesView(viewModel: vm))
+        navigationController.show(vc, sender: nil)
     }
 }

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/Image/RemoteImage.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/Image/RemoteImage.swift
@@ -10,18 +10,18 @@ public struct RemoteImage: View {
     
     @State private var image: Image?
     private let stringURL: String?
-    private let defaultImage: Image
+    private let placeholder: Image
     private let contentMode: ContentMode
     private let failureMessage: String?
     
     public init(
         stringURL: String?,
-        defaultImage: Image,
+        placeholder: Image,
         contentMode: ContentMode = .fit,
         failureMessage: String? = nil
     ) {
         self.stringURL = stringURL
-        self.defaultImage = defaultImage
+        self.placeholder = placeholder
         self.contentMode = contentMode
         self.failureMessage = failureMessage
     }
@@ -45,9 +45,8 @@ private extension RemoteImage {
     
     // MARK: - Subviews
 
-    @ViewBuilder
     func placeholderContent() -> some View {
-        defaultImage
+        placeholder
             .resizable()
             .aspectRatio(contentMode: contentMode)
     }
@@ -67,7 +66,7 @@ private extension RemoteImage {
     
     func downloadRemoteImage(from url: URL) {
         Task {
-            self.image = await downloadImage(from: url)
+            image = await downloadImage(from: url)
         }
     }
     

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/Image/RemoteImage.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/Image/RemoteImage.swift
@@ -12,18 +12,15 @@ public struct RemoteImage: View {
     private let stringURL: String?
     private let placeholder: Image
     private let contentMode: ContentMode
-    private let failureMessage: String?
     
     public init(
         stringURL: String?,
         placeholder: Image,
-        contentMode: ContentMode = .fit,
-        failureMessage: String? = nil
+        contentMode: ContentMode = .fit
     ) {
         self.stringURL = stringURL
         self.placeholder = placeholder
         self.contentMode = contentMode
-        self.failureMessage = failureMessage
     }
     
     public var body: some View {
@@ -36,7 +33,7 @@ public struct RemoteImage: View {
                 .skeleton(true)
                 .onAppear(perform: { downloadRemoteImage(from: url) })
         } else {
-            placeholderContent()
+            failureContent()
         }
     }
 }
@@ -51,15 +48,8 @@ private extension RemoteImage {
             .aspectRatio(contentMode: contentMode)
     }
 
-    @ViewBuilder
     func failureContent() -> some View {
-        if let failureMessage = failureMessage {
-            Text(failureMessage)
-                .font(.caption)
-                .fontWeight(.medium)
-        } else {
-            placeholderContent()
-        }
+        placeholderContent()
     }
     
     // MARK: - Remote image downloading

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/Image/RemoteImage.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/Image/RemoteImage.swift
@@ -1,0 +1,91 @@
+//
+//  Created by David Kadlček on 12.05.2023
+//  Copyright © 2023 Matee. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+public struct RemoteImage: View {
+    
+    @State private var image: Image?
+    private let stringURL: String?
+    private let defaultImage: Image
+    private let contentMode: ContentMode
+    private let failureMessage: String?
+    
+    public init(
+        stringURL: String?,
+        defaultImage: Image,
+        contentMode: ContentMode = .fit,
+        failureMessage: String? = nil
+    ) {
+        self.stringURL = stringURL
+        self.defaultImage = defaultImage
+        self.contentMode = contentMode
+        self.failureMessage = failureMessage
+    }
+    
+    public var body: some View {
+        if let image {
+            image
+                .resizable()
+                .aspectRatio(contentMode: contentMode)
+        } else if let stringURL = stringURL, let url = URL(string: stringURL) {
+            placeholderContent()
+                .skeleton(true)
+                .onAppear(perform: { downloadRemoteImage(from: url) })
+        } else {
+            placeholderContent()
+        }
+    }
+}
+    
+private extension RemoteImage {
+    
+    // MARK: - Subviews
+
+    @ViewBuilder
+    func placeholderContent() -> some View {
+        defaultImage
+            .resizable()
+            .aspectRatio(contentMode: contentMode)
+    }
+
+    @ViewBuilder
+    func failureContent() -> some View {
+        if let failureMessage = failureMessage {
+            Text(failureMessage)
+                .font(.caption)
+                .fontWeight(.medium)
+        } else {
+            placeholderContent()
+        }
+    }
+    
+    // MARK: - Remote image downloading
+    
+    func downloadRemoteImage(from url: URL) {
+        Task {
+            self.image = await downloadImage(from: url)
+        }
+    }
+    
+    func downloadImage(from url: URL) async -> Image? {
+        do {
+            let cache = URLCache.shared
+            let urlRequest = URLRequest(url: url)
+            
+            let (data, response) = try await URLSession.shared.data(for: urlRequest)
+            
+            if cache.cachedResponse(for: urlRequest) == nil {
+                cache.storeCachedResponse(CachedURLResponse(response: response, data: data), for: urlRequest)
+            }
+            
+            guard let uiImage = UIImage(data: data) else { return nil }
+            return Image(uiImage: uiImage)
+        } catch {
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
# :pencil: Description
- There is no way to cache `AsyncImage` with native support. So I create `RemoteImage` that has its own implementation of `URLSession` and caches the `URLRequest`s. I don't like this implementation but on the other hand, it is the easiest way to reuse it in the other projects without creating NetworkProvider, UseCases, ... I thought that I can use `cachePolicy` with `URLRequest` but it doesn't work as expected (It doesn't work at all). So I have to cache the `URLRequest`s manually and it seems like it works. Also, there has to be implemented capacity of the Cache (Memory, Disk), because the default capacity for memory is: 512kB and disk is 10MB. You can put the setting capacity wherever you want, but I put it inside the `ImagesViewModel` to demonstrate it only. 

# :bulb: What’s new?
- Caching images 

# :no_mouth: What’s missing?
- Improve implementation of the `URLSession` to fit the Clean architecture

# :books: References
