### PR TITLE
[iOS] ✨ Add PagingScrollView

### DIFF
--- a/ios/Application/DependencyInjection/Sources/DependencyInjectionMocks/UseCaseMocks.swift
+++ b/ios/Application/DependencyInjection/Sources/DependencyInjectionMocks/UseCaseMocks.swift
@@ -71,7 +71,7 @@ public extension Container {
         
         // User
         let getUsersUseCaseSpy = GetUsersUseCaseSpy()
-        getUsersUseCaseSpy.executePageReturnValue = .stub
+        getUsersUseCaseSpy.executePageLimitReturnValue = .stub
         getUsersUseCase.register { getUsersUseCaseSpy }
         
         let getUserUseCaseSpy = GetUserUseCaseSpy()

--- a/ios/DataLayer/Providers/NetworkProvider/Package.swift
+++ b/ios/DataLayer/Providers/NetworkProvider/Package.swift
@@ -20,13 +20,16 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
+        .package(name: "Utilities", path: "../../../DomainLayer/Utilities")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "NetworkProvider",
-            dependencies: []
+            dependencies: [
+                .product(name: "Utilities", package: "Utilities")
+            ]
         ),
         .target(
             name: "NetworkProviderMocks",

--- a/ios/DataLayer/Providers/NetworkProvider/Sources/NetworkProvider/Pages.swift
+++ b/ios/DataLayer/Providers/NetworkProvider/Sources/NetworkProvider/Pages.swift
@@ -1,0 +1,90 @@
+//
+//  Created by Tomáš Batěk on 24.07.2023
+//  Copyright © 2023 Matee. All rights reserved.
+//
+
+import Foundation
+import Utilities
+
+public struct NETPagination: Decodable {
+    
+    // MARK: Stored properties
+    public let page: Int
+    public let limit: Int
+    public let totalCount: Int
+    public let lastPage: Int
+    
+    // MARK: Init
+    public init(
+        page: Int,
+        limit: Int,
+        totalCount: Int,
+        lastPage: Int
+    ) {
+        self.page = page
+        self.limit = limit
+        self.totalCount = totalCount
+        self.lastPage = lastPage
+    }
+}
+
+// Conversion from NetworkModel to DomainModel
+extension NETPagination: DomainRepresentable {
+    public typealias DomainModel = Pagination
+    
+    public var domainModel: DomainModel {
+        Pagination(
+            page: page,
+            limit: limit,
+            totalCount: totalCount,
+            lastPage: lastPage
+        )
+    }
+}
+
+extension NETPagination: Equatable {}
+
+public struct NETPages<T>: Decodable where T: Decodable {
+    public let data: [T]
+    public let pagination: NETPagination
+    
+    enum CodingKeys: CodingKey {
+        case data
+        case page
+        case limit
+        case totalCount
+        case lastPage
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container: KeyedDecodingContainer<CodingKeys> = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.data = try container.decode([T].self, forKey: .data)
+        self.pagination = NETPagination(
+            page: try container.decode(Int.self, forKey: .page),
+            limit: try container.decode(Int.self, forKey: .limit),
+            totalCount: try container.decode(Int.self, forKey: .totalCount),
+            lastPage: try container.decode(Int.self, forKey: .lastPage)
+        )
+    }
+}
+
+// Conversion from NetworkModel to DomainModel
+extension NETPages: DomainRepresentable where T: DomainRepresentable {
+    public typealias DomainModel = Pages<T.DomainModel>
+    
+    public var domainModel: DomainModel {
+        get throws { // swiftlint:disable:this implicit_getter
+            Pages<T.DomainModel>(
+                data: try data.map { try $0.domainModel },
+                pagination: pagination.domainModel
+            )
+        }
+    }
+}
+
+extension NETPages: Equatable where T: Equatable {
+    public static func == (lhs: NETPages<T>, rhs: NETPages<T>) -> Bool {
+        lhs.data == rhs.data && lhs.pagination == rhs.pagination
+    }
+}

--- a/ios/DataLayer/Providers/NetworkProvider/Sources/NetworkProvider/Representable.swift
+++ b/ios/DataLayer/Providers/NetworkProvider/Sources/NetworkProvider/Representable.swift
@@ -1,0 +1,18 @@
+//
+//  Created by Tomáš Batěk on 24.07.2023
+//  Copyright © 2023 Matee. All rights reserved.
+//
+
+import Foundation
+
+public protocol DomainRepresentable {
+    associatedtype DomainModel
+    
+    var domainModel: DomainModel { get throws }
+}
+
+public protocol NetworkRepresentable {
+    associatedtype NetworkModel
+    
+    var networkModel: NetworkModel { get throws }
+}

--- a/ios/DataLayer/Toolkits/UserToolkit/Sources/UserToolkit/NetworkEndpoints/UserAPI.swift
+++ b/ios/DataLayer/Toolkits/UserToolkit/Sources/UserToolkit/NetworkEndpoints/UserAPI.swift
@@ -8,7 +8,7 @@ import NetworkProvider
 import Utilities
 
 enum UserAPI {
-    case list(_ page: Int)
+    case list(page: Int, limit: Int)
     case read(_ id: String)
     case update(_ id: String, data: [String: Any])
 }
@@ -33,12 +33,16 @@ extension UserAPI: NetworkEndpoint {
     }
     var task: NetworkTask {
         switch self {
-        case let .list(page): .requestParameters(
-            parameters: ["page": page, "limit": 100],
-            encoding: URLEncoding.default
-        )
-        case let .update(_, data): .requestParameters(parameters: data, encoding: JSONEncoding.default)
-        default: .requestPlain
+        case let .list(page, limit):
+            let params: [String: Any] = [
+                "page": page,
+                "limit": limit
+            ]
+            return .requestParameters(parameters: params, encoding: URLEncoding.default)
+        case let .update(_, data):
+            return .requestParameters(parameters: data, encoding: JSONEncoding.default)
+        default:
+            return .requestPlain
         }
     }
 }

--- a/ios/DataLayer/Toolkits/UserToolkit/Sources/UserToolkit/NetworkModels/NETUser.swift
+++ b/ios/DataLayer/Toolkits/UserToolkit/Sources/UserToolkit/NetworkModels/NETUser.swift
@@ -4,8 +4,9 @@
 //
 
 import SharedDomain
+import NetworkProvider
 
-struct NETUser: Codable {
+public struct NETUser: Codable {
     let id: String
     let email: String
     let firstName: String
@@ -16,8 +17,10 @@ struct NETUser: Codable {
 }
 
 // Conversion from NetworkModel to DomainModel
-extension NETUser {
-    var domainModel: User {
+extension NETUser: DomainRepresentable {
+    public typealias DomainModel = User
+    
+    public var domainModel: DomainModel {
         User(
             id: id,
             email: email,
@@ -32,8 +35,10 @@ extension NETUser {
 }
 
 // Conversion from DomainModel to NetworkModel
-extension User {
-    var networkModel: NETUser {
+extension User: NetworkRepresentable {
+    public typealias NetworkModel = NETUser
+    
+    public var networkModel: NetworkModel {
         NETUser(
             id: id,
             email: email,

--- a/ios/DataLayer/Toolkits/UserToolkit/Sources/UserToolkit/Repositories/UserRepository.swift
+++ b/ios/DataLayer/Toolkits/UserToolkit/Sources/UserToolkit/Repositories/UserRepository.swift
@@ -21,7 +21,10 @@ public struct UserRepositoryImpl: UserRepository {
         network = networkProvider
     }
     
-    public func read(_ sourceType: SourceType, id: String) async throws -> User {
+    public func read(
+        _ sourceType: SourceType,
+        id: String
+    ) async throws -> User {
         switch sourceType {
         case .local:
             return try database.read(DBUser.self, id: id).domainModel
@@ -32,7 +35,12 @@ public struct UserRepositoryImpl: UserRepository {
         }
     }
     
-    public func read(_ sourceType: SourceType, page: Int, limit: Int, sortBy: String?) async throws -> Pages<User> {
+    public func read(
+        _ sourceType: SourceType,
+        page: Int,
+        limit: Int,
+        sortBy: String?
+    ) async throws -> Pages<User> {
         switch sourceType {
         case .local:
             let data = try database.read(DBUser.self, sortBy: sortBy)
@@ -53,7 +61,10 @@ public struct UserRepositoryImpl: UserRepository {
         }
     }
     
-    public func update(_ sourceType: SourceType, user: User) async throws -> User {
+    public func update(
+        _ sourceType: SourceType,
+        user: User
+    ) async throws -> User {
         switch sourceType {
         case .local:
             return try database.update(user.databaseModel, model: .fullModel).domainModel

--- a/ios/DataLayer/Toolkits/UserToolkit/Sources/UserToolkit/Repositories/UserRepository.swift
+++ b/ios/DataLayer/Toolkits/UserToolkit/Sources/UserToolkit/Repositories/UserRepository.swift
@@ -6,6 +6,7 @@
 import DatabaseProvider
 import NetworkProvider
 import SharedDomain
+import Utilities
 
 public struct UserRepositoryImpl: UserRepository {
     
@@ -31,14 +32,23 @@ public struct UserRepositoryImpl: UserRepository {
         }
     }
     
-    public func read(_ sourceType: SourceType, page: Int, sortBy: String?) async throws -> [User] {
+    public func read(_ sourceType: SourceType, page: Int, limit: Int, sortBy: String?) async throws -> Pages<User> {
         switch sourceType {
         case .local:
-            return try database.read(DBUser.self, sortBy: sortBy).map { $0.domainModel }
+            let data = try database.read(DBUser.self, sortBy: sortBy)
+            return Pages(
+                data: data.map { $0.domainModel },
+                pagination: Pagination(
+                    page: page,
+                    limit: data.count,
+                    totalCount: data.count,
+                    lastPage: page
+                )
+            )
         case .remote:
-            let endpoint = UserAPI.list(page)
-            let users = try await network.request(endpoint).map([NETUser].self, atKeyPath: "data").map { $0.domainModel }
-            try database.update(users.map { $0.databaseModel })
+            let endpoint = UserAPI.list(page: page, limit: limit)
+            let users = try await network.request(endpoint).map(NETPages<NETUser>.self).domainModel
+            try database.update(users.data.map { $0.databaseModel })
             return users
         }
     }

--- a/ios/DataLayer/Toolkits/UserToolkit/Tests/UserToolkitTests/NetworkStubs/User/NETUserList.json
+++ b/ios/DataLayer/Toolkits/UserToolkit/Tests/UserToolkitTests/NetworkStubs/User/NETUserList.json
@@ -1,7 +1,8 @@
 {
     "page": 0,
-    "limit": 100,
+    "limit": 10,
     "lastPage": 0,
+    "totalCount": 2,
     "data": [
         {
             "id": "5c1a3d7b4a74580016faadf8",

--- a/ios/DataLayer/Toolkits/UserToolkit/Tests/UserToolkitTests/UserRepositoryTests.swift
+++ b/ios/DataLayer/Toolkits/UserToolkit/Tests/UserToolkitTests/UserRepositoryTests.swift
@@ -55,9 +55,9 @@ final class UserRepositoryTests: XCTestCase {
         let repository = createRepository()
         databaseProvider.readCollectionReturnValue = [User].stub.map { $0.databaseModel }
         
-        let users = try await repository.read(.local, page: 0, limit: 100, sortBy: nil)
+        let users = try await repository.read(.local, page: 0, limit: 10, sortBy: nil)
         
-        XCTAssertEqual(users, .stub)
+        XCTAssertEqual(users.data, .stub)
         XCTAssertEqual(networkProvider.requestCallsCount, 0)
         XCTAssertEqual(databaseProvider.readCollectionCallsCount, 1)
     }
@@ -67,9 +67,9 @@ final class UserRepositoryTests: XCTestCase {
         networkProvider.requestReturnData = NETUser.stubList(in: .module)
         databaseProvider.updateCollectionReturnValue = [User].stub.map { $0.databaseModel }
         
-        let users = try await repository.read(.remote, page: 0, limit: 100, sortBy: nil)
+        let users = try await repository.read(.remote, page: 0, limit: 10, sortBy: nil)
         
-        XCTAssertEqual(users, .stub)
+        XCTAssertEqual(users.data, .stub)
         XCTAssertEqual(networkProvider.requestCallsCount, 1)
         XCTAssertEqual(databaseProvider.updateCollectionCallsCount, 1)
     }

--- a/ios/DataLayer/Toolkits/UserToolkit/Tests/UserToolkitTests/UserRepositoryTests.swift
+++ b/ios/DataLayer/Toolkits/UserToolkit/Tests/UserToolkitTests/UserRepositoryTests.swift
@@ -55,7 +55,7 @@ final class UserRepositoryTests: XCTestCase {
         let repository = createRepository()
         databaseProvider.readCollectionReturnValue = [User].stub.map { $0.databaseModel }
         
-        let users = try await repository.read(.local, page: 0, sortBy: nil)
+        let users = try await repository.read(.local, page: 0, limit: 100, sortBy: nil)
         
         XCTAssertEqual(users, .stub)
         XCTAssertEqual(networkProvider.requestCallsCount, 0)
@@ -67,7 +67,7 @@ final class UserRepositoryTests: XCTestCase {
         networkProvider.requestReturnData = NETUser.stubList(in: .module)
         databaseProvider.updateCollectionReturnValue = [User].stub.map { $0.databaseModel }
         
-        let users = try await repository.read(.remote, page: 0, sortBy: nil)
+        let users = try await repository.read(.remote, page: 0, limit: 100, sortBy: nil)
         
         XCTAssertEqual(users, .stub)
         XCTAssertEqual(networkProvider.requestCallsCount, 1)

--- a/ios/DomainLayer/SharedDomain/Package.resolved
+++ b/ios/DomainLayer/SharedDomain/Package.resolved
@@ -1,0 +1,139 @@
+{
+  "pins" : [
+    {
+      "identity" : "aexml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tadija/AEXML.git",
+      "state" : {
+        "revision" : "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
+        "version" : "4.6.1"
+      }
+    },
+    {
+      "identity" : "commander",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Commander.git",
+      "state" : {
+        "revision" : "4b6133c3071d521489a80c38fb92d7983f19d438",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "komondor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/shibapm/Komondor.git",
+      "state" : {
+        "revision" : "90b087b1e39069684b1ff4bf915c2aae594f2d60",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "packageconfig",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/shibapm/PackageConfig.git",
+      "state" : {
+        "revision" : "58523193c26fb821ed1720dcd8a21009055c7cdb",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "pathkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/PathKit.git",
+      "state" : {
+        "revision" : "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "resolver",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hmlongco/Resolver.git",
+      "state" : {
+        "revision" : "97de0b0320036607564af4a60025b48f8d041221",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "semaphore",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/Semaphore",
+      "state" : {
+        "revision" : "f1c4a0acabeb591068dea6cffdd39660b86dec28",
+        "version" : "0.0.8"
+      }
+    },
+    {
+      "identity" : "shellout",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/ShellOut.git",
+      "state" : {
+        "revision" : "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "sourcery",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzysztofzablocki/Sourcery.git",
+      "state" : {
+        "revision" : "eb75bb23ced64ea2e55e3a28adafa4c5a557319e"
+      }
+    },
+    {
+      "identity" : "spectre",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Spectre.git",
+      "state" : {
+        "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+        "version" : "0.10.1"
+      }
+    },
+    {
+      "identity" : "stencil",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stencilproject/Stencil.git",
+      "state" : {
+        "revision" : "4f222ac85d673f35df29962fc4c36ccfdaf9da5b",
+        "version" : "0.15.1"
+      }
+    },
+    {
+      "identity" : "stencilswiftkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftGen/StencilSwiftKit.git",
+      "state" : {
+        "revision" : "20e2de5322c83df005939d9d9300fab130b49f97",
+        "version" : "2.10.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "branch" : "0.50800.0-SNAPSHOT-2022-12-29-a",
+        "revision" : "edd2d0cdb988ac45e2515e0dd0624e4a6de54a94"
+      }
+    },
+    {
+      "identity" : "xcodeproj",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tuist/XcodeProj.git",
+      "state" : {
+        "revision" : "446f3a0db73e141c7f57e26fcdb043096b1db52c",
+        "version" : "8.3.1"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "f47ba4838c30dbd59998a4e4c87ab620ff959e8a",
+        "version" : "5.0.5"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ios/DomainLayer/SharedDomain/Sources/SharedDomain/User/Repositories/UserRepository.swift
+++ b/ios/DomainLayer/SharedDomain/Sources/SharedDomain/User/Repositories/UserRepository.swift
@@ -4,10 +4,24 @@
 //
 
 import Spyable
+import Utilities
 
 @Spyable
 public protocol UserRepository {
-    func read(_ sourceType: SourceType, id: String) async throws -> User
-    func read(_ sourceType: SourceType, page: Int, sortBy: String?) async throws -> [User]
-    func update(_ sourceType: SourceType, user: User) async throws -> User
+    func read(
+        _ sourceType: SourceType,
+        id: String
+    ) async throws -> User
+    
+    func read(
+        _ sourceType: SourceType,
+        page: Int,
+        limit: Int,
+        sortBy: String?
+    ) async throws -> Pages<User>
+    
+    func update(
+        _ sourceType: SourceType,
+        user: User
+    ) async throws -> User
 }

--- a/ios/DomainLayer/SharedDomain/Sources/SharedDomain/User/UseCases/GetUsersUseCase.swift
+++ b/ios/DomainLayer/SharedDomain/Sources/SharedDomain/User/UseCases/GetUsersUseCase.swift
@@ -4,10 +4,15 @@
 //
 
 import Spyable
+import Utilities
 
 @Spyable
 public protocol GetUsersUseCase {
-    func execute(_ sourceType: SourceType, page: Int) async throws -> [User]
+    func execute(
+        _ sourceType: SourceType,
+        page: Int,
+        limit: Int
+    ) async throws -> Pages<User>
 }
 
 public struct GetUsersUseCaseImpl: GetUsersUseCase {
@@ -18,7 +23,11 @@ public struct GetUsersUseCaseImpl: GetUsersUseCase {
         self.userRepository = userRepository
     }
     
-    public func execute(_ sourceType: SourceType, page: Int) async throws -> [User] {
-        try await userRepository.read(sourceType, page: page, sortBy: "id")
+    public func execute(
+        _ sourceType: SourceType,
+        page: Int,
+        limit: Int
+    ) async throws -> Pages<User> {
+        try await userRepository.read(sourceType, page: page, limit: limit, sortBy: "id")
     }
 }

--- a/ios/DomainLayer/SharedDomain/Sources/SharedDomainMocks/Stubs/User/User+Stubs.swift
+++ b/ios/DomainLayer/SharedDomain/Sources/SharedDomainMocks/Stubs/User/User+Stubs.swift
@@ -24,7 +24,7 @@ public extension Pages<User> {
         data: (0..<10).map { _ in User.stub },
         pagination: Pagination(
             page: 0,
-            limit: 100,
+            limit: 10,
             totalCount: 10,
             lastPage: 0
         )

--- a/ios/DomainLayer/SharedDomain/Sources/SharedDomainMocks/Stubs/User/User+Stubs.swift
+++ b/ios/DomainLayer/SharedDomain/Sources/SharedDomainMocks/Stubs/User/User+Stubs.swift
@@ -4,6 +4,7 @@
 //
 
 import SharedDomain
+import Utilities
 
 public extension User {
     static let stub = User(
@@ -15,6 +16,18 @@ public extension User {
         bio: "iOS dev",
         pictureUrl: "",
         counter: 0
+    )
+}
+
+public extension Pages<User> {
+    static let stub = Pages<User>(
+        data: (0..<10).map { _ in User.stub },
+        pagination: Pagination(
+            page: 0,
+            limit: 100,
+            totalCount: 10,
+            lastPage: 0
+        )
     )
 }
 

--- a/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/User/GetUsersUseCaseTests.swift
+++ b/ios/DomainLayer/SharedDomain/Tests/SharedDomainTests/User/GetUsersUseCaseTests.swift
@@ -5,6 +5,7 @@
 
 @testable import SharedDomain
 import XCTest
+import Utilities
 
 final class GetUsersUseCaseTests: XCTestCase {
     
@@ -16,11 +17,11 @@ final class GetUsersUseCaseTests: XCTestCase {
 
     func testExecute() async throws {
         let useCase = GetUsersUseCaseImpl(userRepository: userRepository)
-        userRepository.readPageSortByReturnValue = [User].stub
+        userRepository.readPageLimitSortByReturnValue = Pages<User>.stub
         
-        let users = try await useCase.execute(.local, page: 0)
+        let users = try await useCase.execute(.local, page: 0, limit: 100)
         
-        XCTAssertEqual(users, [User].stub)
-        XCTAssert(userRepository.readPageSortByReceivedInvocations == [(.local, 0, "id")])
+        XCTAssertEqual(users, Pages<User>.stub)
+        XCTAssert(userRepository.readPageLimitSortByReceivedInvocations == [(.local, 0, 100, "id")])
     }
 }

--- a/ios/DomainLayer/Utilities/Sources/Utilities/Pages.swift
+++ b/ios/DomainLayer/Utilities/Sources/Utilities/Pages.swift
@@ -1,0 +1,45 @@
+//
+//  Created by Tomáš Batěk on 24.07.2023
+//  Copyright © 2023 Matee. All rights reserved.
+//
+
+import Foundation
+
+public struct Pagination {
+    
+    // MARK: Stored properties
+    public let page: Int
+    public let limit: Int
+    public let totalCount: Int
+    public let lastPage: Int
+    
+    // MARK: Init
+    public init(
+        page: Int,
+        limit: Int,
+        totalCount: Int,
+        lastPage: Int
+    ) {
+        self.page = page
+        self.limit = limit
+        self.totalCount = totalCount
+        self.lastPage = lastPage
+    }
+}
+
+extension Pagination: Equatable {}
+
+public struct Pages<T> {
+    
+    // MARK: Stored properties
+    public var data: [T]
+    public var pagination: Pagination
+    
+    // MARK: Init
+    public init(data: [T], pagination: Pagination) {
+        self.data = data
+        self.pagination = pagination
+    }
+}
+
+extension Pages: Equatable where T: Equatable {}

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/ScrollView/PagingScrollView.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/ScrollView/PagingScrollView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 /// A Scroll View with the ability to call a certain functionality at a given percentage of scroll
 /// - note: Taken from https://stackoverflow.com/questions/68681075/how-do-i-detect-when-user-has-reached-the-bottom-of-the-scrollview
-struct PagingScrollView<Content: View>: View {
+public struct PagingScrollView<Content: View>: View {
     
     @State private var wholeSize: CGSize = .zero
     @State private var scrollViewSize: CGSize = .zero
@@ -26,7 +26,7 @@ struct PagingScrollView<Content: View>: View {
     ///  - triggerPoint: At which point the `touchedBottomAction` should be triggered, 0.0 would be at the very top, 1.0 at the very bottom
     ///  - touchedBottomAction: The function that should be called when the trigger point is reached
     ///  - content: The content for the scroll view
-    init(
+    public init(
         _ axes: SwiftUI.Axis.Set = .vertical,
         showsIndicators: Bool = true,
         triggerPoint: Double = 1.0,
@@ -42,7 +42,7 @@ struct PagingScrollView<Content: View>: View {
         self.content = content()
     }
     
-    var body: some View {
+    public var body: some View {
         ChildSizeReader(
             size: $wholeSize,
             content: {

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/ScrollView/PagingScrollView.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/ScrollView/PagingScrollView.swift
@@ -18,14 +18,14 @@ public struct PagingScrollView<Content: View>: View {
     private let showsIndicators: Bool
     private let isFetchingMore: Bool
     private let triggerPoint: Double
-    private let touchedBottomAction: (() -> Void)?
+    private let triggerAction: () -> Void
     private let content: Content
     
     /// - parameters:
     ///  - axes: The scroll view axes
     ///  - showIndicators: Whether the scroll indicators are shown
     ///  - isFetchingMore: Whether data is currently being fetched – this prevents from calling `touchedBottomAction` again
-    ///  - triggerPoint: At which point the `touchedBottomAction` should be triggered, 0.0 would be at the very top, 1.0 at the very bottom
+    ///  - triggerPoint: At which point the `triggerAction` should be triggered, 0.0 would be at the very top, 1.0 at the very bottom
     ///  - touchedBottomAction: The function that should be called when the trigger point is reached
     ///  - content: The content for the scroll view
     public init(
@@ -33,14 +33,14 @@ public struct PagingScrollView<Content: View>: View {
         showsIndicators: Bool = true,
         triggerPoint: Double = 1.0,
         isFetchingMore: Bool,
-        touchedBottomAction: (() -> Void)?,
+        triggerAction: @escaping () -> Void,
         @ViewBuilder content: () -> Content
     ) {
         self.axes = axes
         self.showsIndicators = showsIndicators
         self.triggerPoint = triggerPoint
         self.isFetchingMore = isFetchingMore
-        self.touchedBottomAction = touchedBottomAction
+        self.triggerAction = triggerAction
         self.content = content()
     }
     
@@ -88,7 +88,7 @@ public struct PagingScrollView<Content: View>: View {
                               value != 0,
                               value >= actualTriggerPoint
                         else { return }
-                        touchedBottomAction?()
+                        triggerAction()
                     }
             }
         )
@@ -101,7 +101,7 @@ struct PagingScrollView_Previews: PreviewProvider {
     static var previews: some View {
         PagingScrollView(
             isFetchingMore: false,
-            touchedBottomAction: nil,
+            triggerAction: {},
             content: {
                 Text("Hello world!")
             }

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/ScrollView/PagingScrollView.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/ScrollView/PagingScrollView.swift
@@ -1,0 +1,95 @@
+//
+//  Created by Tomáš Batěk on 10.07.2023
+//  Copyright © 2023 Matee. All rights reserved.
+//
+
+import SwiftUI
+
+/// A Scroll View with the ability to call a certain functionality at a given percentage of scroll
+/// - note: Taken from https://stackoverflow.com/questions/68681075/how-do-i-detect-when-user-has-reached-the-bottom-of-the-scrollview
+struct PagingScrollView<Content: View>: View {
+    
+    @State private var wholeSize: CGSize = .zero
+    @State private var scrollViewSize: CGSize = .zero
+    
+    private let axes: SwiftUI.Axis.Set
+    private let showsIndicators: Bool
+    private let isFetchingMore: Bool
+    private let triggerPoint: Double
+    private let touchedBottomAction: (() -> Void)?
+    private let content: Content
+    
+    /// - parameters:
+    ///  - axes: The scroll view axes
+    ///  - showIndicators: Whether the scroll indicators are shown
+    ///  - isFetchingMore: Whether data is currently being fetched – this prevents from calling `touchedBottomAction` again
+    ///  - triggerPoint: At which point the `touchedBottomAction` should be triggered, 0.0 would be at the very top, 1.0 at the very bottom
+    ///  - touchedBottomAction: The function that should be called when the trigger point is reached
+    ///  - content: The content for the scroll view
+    init(
+        _ axes: SwiftUI.Axis.Set = .vertical,
+        showsIndicators: Bool = true,
+        triggerPoint: Double = 1.0,
+        isFetchingMore: Bool,
+        touchedBottomAction: (() -> Void)?,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.axes = axes
+        self.showsIndicators = showsIndicators
+        self.triggerPoint = triggerPoint
+        self.isFetchingMore = isFetchingMore
+        self.touchedBottomAction = touchedBottomAction
+        self.content = content()
+    }
+    
+    var body: some View {
+        ChildSizeReader(
+            size: $wholeSize,
+            content: {
+                ScrollView(axes, showsIndicators: showsIndicators) {
+                    innerChildReader()
+                }
+                .coordinateSpace(name: "scroll")
+            }
+        )
+    }
+    
+    private func innerChildReader() -> some View {
+        ChildSizeReader(
+            size: $scrollViewSize,
+            content: {
+                content
+                    .background(
+                        GeometryReader {
+                            Color.clear.preference(
+                                key: ViewOffsetKey.self,
+                                value: -$0.frame(in: .named("scroll")).origin.y
+                            )
+                        }
+                    )
+                    .onPreferenceChange(ViewOffsetKey.self) { value in
+                        guard !isFetchingMore,
+                              value != 0,
+                              value >= (triggerPoint * scrollViewSize.height - wholeSize.height)
+                        else { return }
+                        touchedBottomAction?()
+                    }
+            }
+        )
+    }
+}
+
+#if DEBUG
+struct PagingScrollView_Previews: PreviewProvider {
+    
+    static var previews: some View {
+        PagingScrollView(
+            isFetchingMore: false,
+            touchedBottomAction: nil,
+            content: {
+                Text("Hello world!")
+            }
+        )
+    }
+}
+#endif

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/SizeReader/ChildSizeReader.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/BaseViews/SwiftUI/SizeReader/ChildSizeReader.swift
@@ -1,0 +1,40 @@
+//
+//  Created by Tomáš Batěk on 10.07.2023
+//  Copyright © 2023 Matee. All rights reserved.
+//
+
+import SwiftUI
+
+struct ChildSizeReader<Content: View>: View {
+    
+    @Binding var size: CGSize
+    
+    private let content: Content
+    
+    init(
+        size: Binding<CGSize>,
+        @ViewBuilder content: () -> Content
+    ) {
+        self._size = size
+        self.content = content()
+    }
+    
+    var body: some View {
+        ZStack {
+            content
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear.preference(
+                            key: SizePreferenceKey.self,
+                            value: proxy.size
+                        )
+                    }
+                )
+        }
+        .onPreferenceChange(SizePreferenceKey.self) { preferences in
+            DispatchQueue.main.async {
+                self.size = preferences
+            }
+        }
+    }
+}

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/Utilities/PagingHandler.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/Utilities/PagingHandler.swift
@@ -1,0 +1,111 @@
+//
+//  Created by Tomáš Batěk on 24.07.2023
+//  Copyright © 2023 Matee. All rights reserved.
+//
+
+import Utilities
+import Foundation
+
+public protocol PagingHandlerDelegate: AnyObject {
+    
+    associatedtype PagingDataType
+    
+    /// Defines the function which fetches the associated data for the given page.
+    ///
+    /// - parameter page: The page which is intended to be loaded
+    /// - returns: Fetched data in the `Pages` form
+    func fetchData(page: Int) async throws -> Pages<PagingDataType>
+    
+    /// Gets called when the fetching more progress has changed
+    func isFetchingMoreChanged(to: Bool)
+    
+    /// Gets called when the data has been updated, usually once it's fetched by the `fetchData(page:)` method
+    func dataUpdated(_: [PagingDataType])
+}
+
+public class AnyPagingHandlerDelegate<T>: PagingHandlerDelegate {
+    
+    public typealias PagingDataType = T
+    
+    private let fetchDataCallback: (_ page: Int) async throws -> Pages<T>
+    private let isFetchingMoreChangedCallback: (Bool) -> Void
+    private let dataUpdatedCallback: ([T]) -> Void
+    
+    public init<U: PagingHandlerDelegate>(_ pagingHandlerDelegate: U) where U.PagingDataType == T {
+        fetchDataCallback = pagingHandlerDelegate.fetchData(page:)
+        isFetchingMoreChangedCallback = pagingHandlerDelegate.isFetchingMoreChanged(to:)
+        dataUpdatedCallback = pagingHandlerDelegate.dataUpdated(_:)
+    }
+    
+    public func fetchData(page: Int) async throws -> Pages<T> {
+        try await fetchDataCallback(page)
+    }
+    
+    public func isFetchingMoreChanged(to value: Bool) {
+        isFetchingMoreChangedCallback(value)
+    }
+    
+    public func dataUpdated(_ data: [T]) {
+        dataUpdatedCallback(data)
+    }
+}
+
+@MainActor
+public class PagingHandler<T> {
+
+    private var currentPage = 1
+    private var totalCount = 0
+    private var hasFetchedAll = false // used only when object count is ignored
+    
+    private let ignoreObjectCount: Bool
+    
+    /// Creates a PagingHandler that simplifies the paging logic. In your view model, use `initData()` for the initial data fetch
+    /// (the first page) and use `handleBottomTouch(originalData:isFetchingMore)` to handle bottom touches. The handler
+    /// then decides whether more data should be fetched. The data will be passed to your view model via the delegate.
+    /// - parameters:
+    ///   - ignoreObjectCount: Whether the `object_count` in the paging data should be ignored. If it's ignored, more data will be fetched
+    ///     until an empty array is returned by `fetchData(page:)`. By default, `object_count` is not ignored, so more data will be fetched
+    ///     until the amount of fetched data is less than `object_count`.
+    public init(ignoreObjectCount: Bool = false) {
+        self.ignoreObjectCount = ignoreObjectCount
+    }
+    
+    // swiftlint:disable:next weak_delegate
+    public var delegate: AnyPagingHandlerDelegate<T>?
+    
+    /// Initializes the data (calls the first page)
+    public func initData() async throws {
+        currentPage = 1
+        hasFetchedAll = false
+        guard let pages: Pages<T> = try await delegate?.fetchData(page: currentPage) else { return }
+        delegate?.dataUpdated(pages.data)
+        totalCount = pages.pagination.totalCount
+    }
+    
+    /// Handles when the user touches the bottom of a scroll view
+    public func handleBottomTouch(
+        originalData: [T],
+        isFetchingMore: Bool
+    ) async throws {
+        guard !isFetchingMore,
+              (ignoreObjectCount || originalData.count < totalCount),
+              !hasFetchedAll
+        else { return }
+        
+        delegate?.isFetchingMoreChanged(to: true)
+        defer {
+            delegate?.isFetchingMoreChanged(to: false)
+        }
+
+        guard let pages: Pages<T> = try await delegate?.fetchData(page: currentPage + 1) else { return }
+        
+        if ignoreObjectCount && pages.data.count < pages.pagination.limit {
+            hasFetchedAll = true
+            return
+        }
+        
+        delegate?.dataUpdated(originalData + pages.data)
+        totalCount = pages.pagination.totalCount
+        currentPage += 1
+    }
+}

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/Utilities/PagingHandler.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/Utilities/PagingHandler.swift
@@ -53,7 +53,7 @@ public class AnyPagingHandlerDelegate<T>: PagingHandlerDelegate {
 @MainActor
 public class PagingHandler<T> {
 
-    private var currentPage = 1
+    private var currentPage = 0
     private var totalCount = 0
     private var hasFetchedAll = false // used only when object count is ignored
     
@@ -75,7 +75,7 @@ public class PagingHandler<T> {
     
     /// Initializes the data (calls the first page)
     public func initData() async throws {
-        currentPage = 1
+        currentPage = 0
         hasFetchedAll = false
         guard let pages: Pages<T> = try await delegate?.fetchData(page: currentPage) else { return }
         delegate?.dataUpdated(pages.data)

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/Utilities/PreferenceKEy/SizePreferenceKey.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/Utilities/PreferenceKEy/SizePreferenceKey.swift
@@ -1,0 +1,17 @@
+//
+//  Created by Tomáš Batěk on 10.07.2023
+//  Copyright © 2023 Matee. All rights reserved.
+//
+
+import SwiftUI
+
+struct SizePreferenceKey: PreferenceKey {
+    typealias Value = CGSize
+    
+    static var defaultValue: Value = .zero
+    
+    static func reduce(value _: inout Value, nextValue: () -> Value) {
+        _ = nextValue()
+    }
+}
+

--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/Utilities/PreferenceKEy/ViewOffsetKey.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/Utilities/PreferenceKEy/ViewOffsetKey.swift
@@ -1,0 +1,17 @@
+//
+//  Created by Tomáš Batěk on 10.07.2023
+//  Copyright © 2023 Matee. All rights reserved.
+//
+
+import SwiftUI
+
+struct ViewOffsetKey: PreferenceKey {
+    
+    typealias Value = CGFloat
+    
+    static var defaultValue = CGFloat.zero
+    
+    static func reduce(value: inout Value, nextValue: () -> Value) {
+        value += nextValue()
+    }
+}

--- a/ios/PresentationLayer/Users/Sources/Users/Main/UsersView.swift
+++ b/ios/PresentationLayer/Users/Sources/Users/Main/UsersView.swift
@@ -21,7 +21,7 @@ struct UsersView: View {
             } else {
                 PagingScrollView(
                     isFetchingMore: viewModel.state.isFetchingMore,
-                    touchedBottomAction: { viewModel.onIntent(.fetchMore) },
+                    triggerAction: { viewModel.onIntent(.fetchMore) },
                     content: {
                         LazyVStack(spacing: 16) {
                             ForEach(viewModel.state.users, id: \.self) { user in

--- a/ios/PresentationLayer/Users/Sources/Users/Main/UsersView.swift
+++ b/ios/PresentationLayer/Users/Sources/Users/Main/UsersView.swift
@@ -19,20 +19,40 @@ struct UsersView: View {
             if viewModel.state.users.isEmpty && viewModel.state.isLoading {
                 PrimaryProgressView()
             } else {
-                List {
-                    ForEach(viewModel.state.users, id: \.self) { user in
-                        HStack {
-                            Text(user.fullName)
-                            Spacer()
-                            NavigationLink.empty
+                PagingScrollView(
+                    isFetchingMore: viewModel.state.isFetchingMore,
+                    touchedBottomAction: { viewModel.onIntent(.fetchMore) },
+                    content: {
+                        LazyVStack(spacing: 16) {
+                            ForEach(viewModel.state.users, id: \.self) { user in
+                                Button(
+                                    action: { viewModel.onIntent(.openUserDetail(id: user.id)) },
+                                    label: {
+                                        HStack {
+                                            Text(user.fullName)
+                                            
+                                            Spacer()
+                                            
+                                            Image(systemName: "chevron.right")
+                                        }
+                                        .contentShape(Rectangle())
+                                        .padding()
+                                        .background(Color.gray.opacity(0.3))
+                                        .cornerRadius(10)
+                                        .padding(.horizontal)
+                                    }
+                                )
+                                .shadow(radius: 10, y: 10)
+                                .foregroundColor(Color.primary)
+                            }
+                            
+                            if viewModel.state.isFetchingMore {
+                                ProgressView()
+                            }
                         }
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            viewModel.onIntent(.openUserDetail(id: user.id))
-                        }
+                        .padding(.vertical)
                     }
-                }
-                .listStyle(PlainListStyle())
+                )
             }
         }
         .lifecycle(viewModel)

--- a/ios/PresentationLayer/Users/Sources/Users/Main/UsersViewModel.swift
+++ b/ios/PresentationLayer/Users/Sources/Users/Main/UsersViewModel.swift
@@ -63,6 +63,7 @@ final class UsersViewModel: BaseViewModel, ViewModel, ObservableObject {
     
     private func initData() async {
         do {
+            state.users = try await getUsersUseCase.execute(.local, page: 0, limit: pageLimit).data
             try await pagingHandler.initData()
         } catch {}
     }

--- a/ios/PresentationLayer/Users/Sources/Users/Main/UsersViewModel.swift
+++ b/ios/PresentationLayer/Users/Sources/Users/Main/UsersViewModel.swift
@@ -8,8 +8,12 @@ import Factory
 import SharedDomain
 import SwiftUI
 import UIToolkit
+import Utilities
 
 final class UsersViewModel: BaseViewModel, ViewModel, ObservableObject {
+    
+    private let pagingHandler = PagingHandler<User>()
+    private let pageLimit = 10
     
     // MARK: Dependencies
     private weak var flowController: FlowController?
@@ -19,13 +23,15 @@ final class UsersViewModel: BaseViewModel, ViewModel, ObservableObject {
     init(flowController: FlowController?) {
         self.flowController = flowController
         super.init()
+        
+        pagingHandler.delegate = AnyPagingHandlerDelegate(self)
     }
     
     // MARK: Lifecycle
     
     override func onAppear() {
         super.onAppear()
-        executeTask(Task { await loadUsers() })
+        executeTask(Task { await initData() })
     }
     
     // MARK: State
@@ -35,33 +41,58 @@ final class UsersViewModel: BaseViewModel, ViewModel, ObservableObject {
     struct State {
         var isLoading: Bool = false
         var users: [User] = []
+        var isFetchingMore = false
     }
     
     // MARK: Intent
     enum Intent {
         case openUserDetail(id: String)
+        case fetchMore
     }
 
     func onIntent(_ intent: Intent) {
         executeTask(Task {
             switch intent {
             case .openUserDetail(let id): openUserDetail(id)
+            case .fetchMore: await fetchMore()
             }
         })
     }
     
     // MARK: Private
     
-    private func loadUsers() async {
+    private func initData() async {
         do {
-            state.isLoading = true
-            state.users = try await getUsersUseCase.execute(.local, page: 0)
-            state.users = try await getUsersUseCase.execute(.remote, page: 0)
-            state.isLoading = false
+            try await pagingHandler.initData()
+        } catch {}
+    }
+    
+    private func fetchMore() async {
+        do {
+            try await pagingHandler.handleBottomTouch(
+                originalData: state.users,
+                isFetchingMore: state.isFetchingMore
+            )
         } catch {}
     }
     
     private func openUserDetail(_ id: String) {
         flowController?.handleFlow(UsersFlow.users(.showUserDetailForId(id)))
+    }
+}
+
+extension UsersViewModel: PagingHandlerDelegate {
+    typealias PagingDataType = User
+    
+    func fetchData(page: Int) async throws -> Pages<PagingDataType> {
+        try await getUsersUseCase.execute(.remote, page: page, limit: pageLimit)
+    }
+    
+    func isFetchingMoreChanged(to isFetchingMore: Bool) {
+        state.isFetchingMore = isFetchingMore
+    }
+    
+    func dataUpdated(_ data: [PagingDataType]) {
+        state.users = data
     }
 }

--- a/ios/PresentationLayer/Users/Tests/UsersTests/UsersViewModelTests.swift
+++ b/ios/PresentationLayer/Users/Tests/UsersTests/UsersViewModelTests.swift
@@ -39,8 +39,8 @@ final class UsersViewModelTests: XCTestCase {
         XCTAssertEqual(vm.state.users, Pages<User>.stub.data)
         XCTAssertEqual(vm.state.isLoading, false)
         XCTAssert(getUsersUseCase.executePageLimitReceivedInvocations == [
-            (.local, 0, 100),
-            (.remote, 0, 100)
+            (.local, 0, 10),
+            (.remote, 0, 10)
         ])
     }
     

--- a/ios/PresentationLayer/Users/Tests/UsersTests/UsersViewModelTests.swift
+++ b/ios/PresentationLayer/Users/Tests/UsersTests/UsersViewModelTests.swift
@@ -31,16 +31,16 @@ final class UsersViewModelTests: XCTestCase {
     
     func testAppear() async {
         let vm = createViewModel()
-        getUsersUseCase.executePageReturnValue = [User].stub
+        getUsersUseCase.executePageLimitReturnValue = Pages<User>.stub
         
         vm.onAppear()
         await vm.awaitAllTasks()
         
-        XCTAssertEqual(vm.state.users, [User].stub)
+        XCTAssertEqual(vm.state.users, Pages<User>.stub.data)
         XCTAssertEqual(vm.state.isLoading, false)
-        XCTAssert(getUsersUseCase.executePageReceivedInvocations == [
-            (.local, 0),
-            (.remote, 0)
+        XCTAssert(getUsersUseCase.executePageLimitReceivedInvocations == [
+            (.local, 0, 100),
+            (.remote, 0, 100)
         ])
     }
     


### PR DESCRIPTION
# :pencil: Description
- This PR adds a `PagingScrollView` component, which can be useful for handling paging.

# :bulb: What’s new?
- The `PagingScrollView` is a scroll view with the ability to call a given function when the scroll offset reaches a certain percentage. This function serves as a trigger for fetching a next page.

# :no_mouth: What’s missing?
- There are no appropriate views in DevStack where the `PagingScrollView` could be used, because it requires the data to come in a paging type. A usage example can be found in Můj Up, for example [here](https://github.com/MateeDevs/updigital-ios/blob/develop/PresentationLayer/Sources/PresentationLayer/App/Home/UserProfile/MyProfile/PersonalProfileBadges/PersonalProfileAllBadges/PersonalProfileAllBadgesView.swift).

# :books: References
- https://github.com/MateeDevs/updigital-ios/pull/1071
