### PR TITLE
[iOS] Run Twine via SPM plugin

### DIFF
--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack.xcscheme
@@ -5,24 +5,6 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <PreActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Generate code"
-               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild.log 2&gt;&amp;1 # For debugging&#10;scripts/twine.sh&#10;">
-               <EnvironmentBuildable>
-                  <BuildableReference
-                     BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "4558D30620FCC8FF005BC325"
-                     BuildableName = "DevStack.app"
-                     BlueprintName = "DevStack"
-                     ReferencedContainer = "container:DevStack.xcodeproj">
-                  </BuildableReference>
-               </EnvironmentBuildable>
-            </ActionContent>
-         </ExecutionAction>
-      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForDevStacking = "YES"

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha.xcscheme
@@ -5,24 +5,6 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <PreActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Generate code"
-               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild.log 2&gt;&amp;1 # For debugging&#10;scripts/twine.sh&#10;">
-               <EnvironmentBuildable>
-                  <BuildableReference
-                     BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "4558D30620FCC8FF005BC325"
-                     BuildableName = "DevStack.app"
-                     BlueprintName = "DevStack"
-                     ReferencedContainer = "container:DevStack.xcodeproj">
-                  </BuildableReference>
-               </EnvironmentBuildable>
-            </ActionContent>
-         </ExecutionAction>
-      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta.xcscheme
@@ -5,24 +5,6 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <PreActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Generate code"
-               scriptText = "cd &quot;${PROJECT_DIR}&quot;&#10;exec &gt; prebuild.log 2&gt;&amp;1 # For debugging&#10;scripts/twine.sh&#10;">
-               <EnvironmentBuildable>
-                  <BuildableReference
-                     BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "4558D30620FCC8FF005BC325"
-                     BuildableName = "DevStack.app"
-                     BlueprintName = "DevStack"
-                     ReferencedContainer = "container:DevStack.xcodeproj">
-                  </BuildableReference>
-               </EnvironmentBuildable>
-            </ActionContent>
-         </ExecutionAction>
-      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/ios/PresentationLayer/UIToolkit/Package.swift
+++ b/ios/PresentationLayer/UIToolkit/Package.swift
@@ -34,8 +34,13 @@ let package = Package(
                 "swiftgen.yml"
             ],
             plugins: [
+                "TwinePlugin",
                 .plugin(name: "SwiftGenPlugin", package: "SwiftGenPlugin")
             ]
+        ),
+        .plugin(
+            name: "TwinePlugin",
+            capability: .buildTool()
         )
     ]
 )

--- a/ios/PresentationLayer/UIToolkit/Plugins/TwinePlugin/TwinePlugin.swift
+++ b/ios/PresentationLayer/UIToolkit/Plugins/TwinePlugin/TwinePlugin.swift
@@ -1,0 +1,29 @@
+//
+//  Created by Petr Chmelar on 02.08.2023
+//  Copyright © 2023 Matee. All rights reserved.
+//
+
+import Foundation
+import PackagePlugin
+
+@main
+struct TwinePlugin: BuildToolPlugin {
+    
+    func createBuildCommands(
+        context: PluginContext,
+        target: Target
+    ) throws -> [Command] {
+        let rootPath = context.package.directory
+            .removingLastComponent()
+            .removingLastComponent()
+        
+        return [
+            .prebuildCommand(
+                displayName: "Run Twine",
+                executable: rootPath.appending(["scripts", "twine.sh"]),
+                arguments: [],
+                outputFilesDirectory: context.pluginWorkDirectory
+            )
+        ]
+    }
+}

--- a/ios/scripts/apollo.sh
+++ b/ios/scripts/apollo.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
+# This ensures that relative paths are correct no matter where the script is executed
 cd "$(dirname "$0")"
-cd ../DataLayer/Providers/GraphQLProvider
 
 echo "⚙️  RocketToolkit - Downloading GraphQL schema and generating code from queries"
-swift package --disable-sandbox --allow-writing-to-package-directory apollo-fetch-schema --path "../../Toolkits/RocketToolkit/apollo-codegen-config.json"
-swift package --disable-sandbox --allow-writing-to-package-directory apollo-generate --path "../../Toolkits/RocketToolkit/apollo-codegen-config.json"
+swift package --disable-sandbox --allow-writing-to-package-directory apollo-fetch-schema --path "../DataLayer/Toolkits/RocketToolkit/apollo-codegen-config.json"
+swift package --disable-sandbox --allow-writing-to-package-directory apollo-generate --path "../DataLayer/Toolkits/RocketToolkit/apollo-codegen-config.json"

--- a/ios/scripts/build-kmp.sh
+++ b/ios/scripts/build-kmp.sh
@@ -12,8 +12,8 @@
 # ./scripts/build-kmp.sh release false true false   -> release configuration with arm64 architecture (TestFlight/AppStore builds)
 #
 
-# This ensures that relative paths are correct no matter where the script is executed.
-cd "$(dirname "$0")/../.."
+# This ensures that relative paths are correct no matter where the script is executed
+cd "$(dirname "$0")"
 
 # Read input arguments
 configuration=$1
@@ -22,5 +22,6 @@ arm64=$3
 arm64sim=$4
 
 # Build and copy XCFramework
+cd ../..
 ./gradlew :shared:buildXCFramework -PXCODE_CONFIGURATION=${configuration} -PX86=${x86} -PARM64=${arm64} -PARM64SIM=${arm64sim}
 ./gradlew :shared:copyXCFramework -PXCODE_CONFIGURATION=${configuration} -PX86=${x86} -PARM64=${arm64} -PARM64SIM=${arm64sim}

--- a/ios/scripts/rename.sh
+++ b/ios/scripts/rename.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# This ensures that relative paths are correct no matter where the script is executed
 cd "$(dirname "$0")"
 
 old_name="DevStack"

--- a/ios/scripts/setup.sh
+++ b/ios/scripts/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This ensures that relative paths are correct no matter where the script is executed.
+# This ensures that relative paths are correct no matter where the script is executed
 cd "$(dirname "$0")"
 
 echo "⚙️  Checking file header"
@@ -30,6 +30,6 @@ echo "⚙️  Checking whether Twine is installed"
 if command -v twine &> /dev/null; then
   echo "✅ Twine is installed"
 else
-  echo "❌ Twine is not installed - installing now"
-  gem install twine
+  echo "❌ Twine is not installed"
+  echo "Check https://github.com/MateeDevs/wiki/blob/master/tooling/ruby.md for more info"
 fi

--- a/ios/scripts/sourcery.sh
+++ b/ios/scripts/sourcery.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
+# This ensures that relative paths are correct no matter where the script is executed
 cd "$(dirname "$0")"
 
-# SharedDomain
+echo "⚙️  SharedDomain - Generating mocks for UseCases and Repositories"
 cd ../DomainLayer/SharedDomain
-swift package --disable-sandbox --allow-writing-to-package-directory sourcery-command
+swift package --disable-sandbox --allow-writing-to-package-directory sourcery-command --sources "../DomainLayer/SharedDomain"
 cd ../..

--- a/ios/scripts/swiftlint-analyze.sh
+++ b/ios/scripts/swiftlint-analyze.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
+# This ensures that relative paths are correct no matter where the script is executed
 cd "$(dirname "$0")"
-cd ..
 
-echo "Building project in order to obtain xcodebuild.log"
-xcodebuild -workspace DevStack.xcworkspace -scheme DevStack_Alpha > xcodebuild.log
+echo "⚙️  Building project in order to obtain xcodebuild.log"
+xcodebuild -workspace ../DevStack.xcworkspace -scheme ../DevStack_Alpha > ../xcodebuild.log
 
-echo "Running SwiftLint Static Analyzer"
-swiftlint analyze --config .swiftlint.yml --compiler-log-path xcodebuild.log
+echo "⚙️  Running SwiftLint Static Analyzer"
+swiftlint analyze --config ../swiftlint.yml --compiler-log-path ../xcodebuild.log

--- a/ios/scripts/twine.sh
+++ b/ios/scripts/twine.sh
@@ -1,7 +1,10 @@
 #!/bin/zsh -l
 
-echo "Generating Localizable files for specified languages"
-twine generate-localization-file ../twine/strings.txt PresentationLayer/UIToolkit/Sources/UIToolkit/Resources/Localizable/Base.lproj/Localizable.strings --lang en
-twine generate-localization-file ../twine/strings.txt PresentationLayer/UIToolkit/Sources/UIToolkit/Resources/Localizable/cs.lproj/Localizable.strings --lang cs
-twine generate-localization-file ../twine/strings.txt PresentationLayer/UIToolkit/Sources/UIToolkit/Resources/Localizable/sk.lproj/Localizable.strings --lang sk
-twine generate-localization-file ../twine/strings.txt PresentationLayer/UIToolkit/Sources/UIToolkit/Resources/Localizable/en.lproj/Localizable.strings --lang en
+# This ensures that relative paths are correct no matter where the script is executed
+cd "$(dirname "$0")"
+
+echo "⚙️  Generating Localizable files for specified languages"
+twine generate-localization-file ../../twine/strings.txt ../PresentationLayer/UIToolkit/Sources/UIToolkit/Resources/Localizable/Base.lproj/Localizable.strings --lang en
+twine generate-localization-file ../../twine/strings.txt ../PresentationLayer/UIToolkit/Sources/UIToolkit/Resources/Localizable/cs.lproj/Localizable.strings --lang cs
+twine generate-localization-file ../../twine/strings.txt ../PresentationLayer/UIToolkit/Sources/UIToolkit/Resources/Localizable/sk.lproj/Localizable.strings --lang sk
+twine generate-localization-file ../../twine/strings.txt ../PresentationLayer/UIToolkit/Sources/UIToolkit/Resources/Localizable/en.lproj/Localizable.strings --lang en


### PR DESCRIPTION
# :pencil: Description
- This PR replaces build pre-action for running Twine with SPM plugin 🚀 

# :bulb: What’s new?
- `TwinePlugin` as SPM BuildToolPlugin in UIToolkit package that executes `scripts/twine.sh` as pre-build command ensuring that `Localizable.strings` are produced before the build of UIToolkit package. Finally we can see log/errors directly in the Xcode. 🥳 
- We need to run `TwinePlugin` before `SwiftGenPlugin`. From my experimentation it seems that order of plugins in target is not guaranteed, but it seems that local plugins are always executed before remote ones, so it works for now. 😅 
- Unify all scripts to ensure correct relative paths

# :no_mouth: What’s missing?
- Twine as self-contained tool (without the need to install Ruby)

# :books: References
- https://github.com/MateeDevs/devstack-native-app/pull/82
- https://github.com/scelis/twine
