### PR TITLE
[iOS] Example of GoogleMaps via SPM 🗺️

### DIFF
--- a/ios/DevStack.xcodeproj/project.pbxproj
+++ b/ios/DevStack.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		45DEBE3627A401A40075C7E2 /* Prod.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Prod.entitlements; sourceTree = "<group>"; };
 		45DEBE3727A401A40075C7E2 /* Beta.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Beta.entitlements; sourceTree = "<group>"; };
 		45DEBE3827A401A40075C7E2 /* Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Alpha.entitlements; sourceTree = "<group>"; };
+		45E968362A7C4266004C3F15 /* MapToolkit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = MapToolkit; sourceTree = "<group>"; };
 		45FF99D32842A8CB00E32D9A /* RemoteConfigProvider */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = RemoteConfigProvider; sourceTree = "<group>"; };
 		45FF99D52842AAFB00E32D9A /* UserDefaultsProvider */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = UserDefaultsProvider; sourceTree = "<group>"; };
 		45FF99D72842B0A600E32D9A /* AnalyticsToolkit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = AnalyticsToolkit; sourceTree = "<group>"; };
@@ -211,6 +212,7 @@
 				4508333928437FC600BC9460 /* Users */,
 				4508333A28437FD600BC9460 /* Profile */,
 				4508333B28437FE200BC9460 /* Recipes */,
+				45E968362A7C4266004C3F15 /* MapToolkit */,
 				4508333128436EFB00BC9460 /* UIToolkit */,
 				453580EE284806FE007AEC9E /* strings.txt */,
 			);

--- a/ios/DevStack.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/DevStack.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -100,6 +100,15 @@
       }
     },
     {
+      "identity" : "googlemaps-sp",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MateeDevs/GoogleMaps-SP.git",
+      "state" : {
+        "revision" : "0c1940aff2ca9da9d28598ae586234f3fff747ab",
+        "version" : "7.4.0"
+      }
+    },
+    {
       "identity" : "googleutilities",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",

--- a/ios/DomainLayer/Utilities/Sources/Utilities/NetworkingConstants.swift
+++ b/ios/DomainLayer/Utilities/Sources/Utilities/NetworkingConstants.swift
@@ -19,4 +19,12 @@ public struct NetworkingConstants {
         case .production: return "https://apollo-fullstack-tutorial.herokuapp.com/graphql"
         }
     }
+    
+    public static var googleMapsAPIKey: String {
+        switch Environment.type {
+        case .alpha: return "AIzaSyDj2cQ3ASrD9GCG7O3UIihcovCNihIXjDs"
+        case .beta: return "AIzaSyDj2cQ3ASrD9GCG7O3UIihcovCNihIXjDs"
+        case .production: return "AIzaSyDj2cQ3ASrD9GCG7O3UIihcovCNihIXjDs"
+        }
+    }
 }

--- a/ios/PresentationLayer/MapToolkit/.gitignore
+++ b/ios/PresentationLayer/MapToolkit/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/ios/PresentationLayer/MapToolkit/Package.swift
+++ b/ios/PresentationLayer/MapToolkit/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 5.6
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "MapToolkit",
+    platforms: [.iOS(.v14)],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "MapToolkit",
+            targets: ["MapToolkit"]
+        )
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+        .package(name: "Utilities", path: "../../DomainLayer/Utilities"),
+        .package(url: "https://github.com/MateeDevs/GoogleMaps-SP.git", .upToNextMinor(from: "7.4.0"))
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "MapToolkit",
+            dependencies: [
+                .product(name: "Utilities", package: "Utilities"),
+                .product(name: "GoogleMaps", package: "GoogleMaps-SP")
+            ]
+        )
+    ]
+)

--- a/ios/PresentationLayer/MapToolkit/Sources/MapToolkit/Views/GoogleMapsView.swift
+++ b/ios/PresentationLayer/MapToolkit/Sources/MapToolkit/Views/GoogleMapsView.swift
@@ -1,0 +1,24 @@
+//
+//  Created by Petr Chmelar on 03.08.2023
+//  Copyright © 2023 Matee. All rights reserved.
+//
+
+import GoogleMaps
+import SwiftUI
+import UIToolkit
+import Utilities
+
+public struct GoogleMapsView: UIViewRepresentable {
+    
+    public init() {
+        // Provide GoogleMaps API key
+        GMSServices.provideAPIKey(NetworkingConstants.googleMapsAPIKey)
+    }
+    
+    public func makeUIView(context: Context) -> GMSMapView {
+        let mapView = GMSMapView(frame: .zero)
+        return mapView
+    }
+    
+    public func updateUIView(_ uiView: GMSMapView, context: Context) {}
+}

--- a/ios/PresentationLayer/Recipes/Package.swift
+++ b/ios/PresentationLayer/Recipes/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(name: "UIToolkit", path: "../UIToolkit"),
+        .package(name: "MapToolkit", path: "../MapToolkit"),
         .package(name: "Utilities", path: "../../DomainLayer/Utilities"),
         .package(name: "SharedDomain", path: "../../DomainLayer/SharedDomain"),
         .package(url: "https://github.com/hmlongco/Resolver.git", .upToNextMajor(from: "1.0.0"))
@@ -28,6 +29,7 @@ let package = Package(
             name: "Recipes",
             dependencies: [
                 .product(name: "UIToolkit", package: "UIToolkit"),
+                .product(name: "MapToolkit", package: "MapToolkit"),
                 .product(name: "Utilities", package: "Utilities"),
                 .product(name: "SharedDomain", package: "SharedDomain"),
                 .product(name: "SharedDomainMocks", package: "SharedDomain"),

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/Main/RecipesViewModel.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/Main/RecipesViewModel.swift
@@ -12,6 +12,7 @@ enum Recipe: String, CaseIterable {
     case rocketLaunches = "RocketLaunches"
     case skeleton = "Skeleton"
     case images = "Images"
+    case maps = "Maps"
 }
 
 final class RecipesViewModel: BaseViewModel, ViewModel, ObservableObject {
@@ -59,6 +60,8 @@ final class RecipesViewModel: BaseViewModel, ViewModel, ObservableObject {
             flowController?.handleFlow(RecipesFlow.recipes(.showSkeleton))
         case .images:
             flowController?.handleFlow(RecipesFlow.recipes(.showImages))
+        case .maps:
+            flowController?.handleFlow(RecipesFlow.recipes(.showMaps))
         }
     }
 }

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/Maps/MapsView.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/Maps/MapsView.swift
@@ -1,0 +1,40 @@
+//
+//  Created by Petr Chmelar on 03.08.2023
+//  Copyright © 2023 Matee. All rights reserved.
+//
+
+import MapToolkit
+import SwiftUI
+import UIToolkit
+
+struct MapsView: View {
+    
+    @ObservedObject private var viewModel: MapsViewModel
+    
+    init(viewModel: MapsViewModel) {
+        self.viewModel = viewModel
+    }
+    
+    var body: some View {
+        return VStack {
+            GoogleMapsView()
+        }
+        .lifecycle(viewModel)
+    }
+}
+
+#if DEBUG
+import Resolver
+import SharedDomainMocks
+
+struct MapsView_Previews: PreviewProvider {
+    static var previews: some View {
+        Resolver.registerUseCaseMocks()
+        
+        let vm = MapsViewModel(flowController: nil)
+        return PreviewGroup {
+            MapsView(viewModel: vm)
+        }
+    }
+}
+#endif

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/Maps/MapsViewModel.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/Maps/MapsViewModel.swift
@@ -1,0 +1,39 @@
+//
+//  Created by Petr Chmelar on 03.08.2023
+//  Copyright © 2023 Matee. All rights reserved.
+//
+
+import SwiftUI
+import UIToolkit
+
+final class MapsViewModel: BaseViewModel, ViewModel, ObservableObject {
+    
+    // MARK: Dependencies
+    private weak var flowController: FlowController?
+
+    init(flowController: FlowController?) {
+        self.flowController = flowController
+        super.init()
+    }
+    
+    // MARK: Lifecycle
+    
+    override func onAppear() {
+        super.onAppear()
+    }
+    
+    // MARK: State
+    
+    @Published private(set) var state: State = State()
+
+    struct State {
+    }
+    
+    // MARK: Intent
+    enum Intent {
+    }
+
+    func onIntent(_ intent: Intent) {}
+    
+    // MARK: Private
+}

--- a/ios/PresentationLayer/Recipes/Sources/Recipes/RecipesFlowController.swift
+++ b/ios/PresentationLayer/Recipes/Sources/Recipes/RecipesFlowController.swift
@@ -16,6 +16,7 @@ enum RecipesFlow: Flow, Equatable {
         case showRocketLaunches
         case showSkeleton
         case showImages
+        case showMaps
     }
 }
 
@@ -43,6 +44,7 @@ extension RecipesFlowController {
         case .showRocketLaunches: showRocketLaunches()
         case .showSkeleton: showSkeleton()
         case .showImages: showImages()
+        case .showMaps: showMaps()
         }
     }
     
@@ -73,6 +75,12 @@ extension RecipesFlowController {
     private func showImages() {
         let vm = ImagesViewModel(flowController: self)
         let vc = BaseHostingController(rootView: ImagesView(viewModel: vm))
+        navigationController.show(vc, sender: nil)
+    }
+    
+    private func showMaps() {
+        let vm = MapsViewModel(flowController: self)
+        let vc = BaseHostingController(rootView: MapsView(viewModel: vm))
         navigationController.show(vc, sender: nil)
     }
 }


### PR DESCRIPTION
# :pencil: Description
- This PR adds an example of integrating GoogleMaps via SPM

# :bulb: What’s new?
- GoogleMaps are integrated via SPM. No more frameworks and bundles directly in the repo 🙅 
- `MapsToolkit` package to prevent direct 3rd party dependency in other packages. For now, it contains only a simple `GoogleMapsView`. We can add more functionality/examples later.
- Google Maps API key is provided directly in `GoogleMapsView` to avoid having 3rd party dependency in the main target. It will be invoked every time this view is initialized, but I guess that's not a big deal? 🤔 

# :no_mouth: What’s missing?
- 8.0.0 is not working for some unknown reasons - https://github.com/MateeDevs/GoogleMaps-SP/pull/1

# :books: References
- https://github.com/MateeDevs/GoogleMaps-SP
- https://developers.google.com/codelabs/maps-platform/maps-platform-ios-swiftui#0
