### PR TITLE
[iOS] Fix KMP build for Xcode 15

### DIFF
--- a/build-logic/convention/src/main/kotlin/cz/matee/devstack/config/KmmConfig.kt
+++ b/build-logic/convention/src/main/kotlin/cz/matee/devstack/config/KmmConfig.kt
@@ -77,6 +77,7 @@ fun KotlinMultiplatformExtension.kmm(
         KmmConfig.getSupportedMobilePlatforms(this@kmm, project).forEach {
             it.binaries.framework {
                 if (this.buildType == KmmConfig.getCurrentNativeBuildType(project)) {
+                    linkerOpts += "-ld64"
                     baseName = nativeName
                     isStatic = false
                     xcf.add(this)
@@ -87,6 +88,7 @@ fun KotlinMultiplatformExtension.kmm(
             KmmConfig.getSupportedTvPlatforms(this@kmm, project).forEach {
                 it.binaries.framework {
                     if (this.buildType == KmmConfig.getCurrentNativeBuildType(project)) {
+                        linkerOpts += "-ld64"
                         baseName = nativeName
                         isStatic = false
                         xcf.add(this)


### PR DESCRIPTION
# :pencil: Description
- This PR fixes KMP build for Xcode 15

# :bulb: What’s new?
- As mentioned in https://github.com/MateeDevs/devstack-native-app/pull/86, the KMP build stopped working under Xcode 15. It is because Apple changed the default linker from `ld64` to `ld-prime`.
- This issue is fixed in Kotlin 1.9.10, but we can use a temporary workaround until we update - add `linkerOpts += "-ld64"` to `KmmConfig`. It breaks the KMP build under Xcode 14, but we don't care about it. Note that suggested `System.getenv("XCODE_VERSION_MAJOR") == "1500"` [doesn't work](https://slack-chats.kotlinlang.org/t/13149344/there-seems-to-be-a-compatibility-issue-with-the-latest-xcod) when running from the command line.

# :no_mouth: What’s missing?
- Update to Kotlin 1.9.10 and remove the workaround

# :books: References
- https://youtrack.jetbrains.com/issue/KT-60230/Native-unknown-options-iossimulatorversionmin-sdkversion-with-Xcode-15-beta-3
