### PR TITLE
🌐 [iOS] Use error messages from Moko strings in tests

### DIFF
--- a/android/shared/src/main/res/values-en/generated_strings.xml
+++ b/android/shared/src/main/res/values-en/generated_strings.xml
@@ -31,6 +31,7 @@
 	<string name="sending">Sending…</string>
 	<string name="signing_in">Signing in…</string>
 	<string name="signing_up">Signing up…</string>
+	<string name="signing_up_failed">Sign up failed</string>
 	<string name="signing_out">Signing out…</string>
 	<string name="invite">Invite</string>
 	<string name="email_client">Email client</string>
@@ -184,6 +185,7 @@
 	<string name="registration_view_password_field_hint">Password</string>
 	<string name="registration_view_register_button_title">Register</string>
 	<string name="registration_view_login_button_title">Sign in</string>
+	<string name="register_view_email_already_exists">User with specified email already exists.</string>
 
 	<!-- SECTION: Users View -->
 	<string name="users_view_toolbar_title">Users</string>

--- a/android/shared/src/main/res/values-sk/generated_strings.xml
+++ b/android/shared/src/main/res/values-sk/generated_strings.xml
@@ -31,6 +31,7 @@
 	<string name="sending">Odosieľam...</string>
 	<string name="signing_in">Prihlasujem...</string>
 	<string name="signing_up">Registrujem...</string>
+	<string name="signing_up_failed">Registrácia sa nepodarila</string>
 	<string name="signing_out">Odhlasujem...</string>
 	<string name="invite">Pozvať</string>
 	<string name="email_client">E-mailový klient</string>
@@ -184,6 +185,7 @@
 	<string name="registration_view_password_field_hint">Heslo</string>
 	<string name="registration_view_register_button_title">Registrovať sa</string>
 	<string name="registration_view_login_button_title">Prihlásiť sa</string>
+	<string name="register_view_email_already_exists">Užívateľ s daným emailom už existuje.</string>
 
 	<!-- SECTION: Users View -->
 	<string name="users_view_toolbar_title">Užívatelia</string>

--- a/android/shared/src/main/res/values/generated_strings.xml
+++ b/android/shared/src/main/res/values/generated_strings.xml
@@ -31,6 +31,7 @@
 	<string name="sending">Odesílám…</string>
 	<string name="signing_in">Přihlašuji…</string>
 	<string name="signing_up">Registruji…</string>
+	<string name="signing_up_failed">Registrace se nezdařila</string>
 	<string name="signing_out">Odhlašuji…</string>
 	<string name="invite">Pozvat</string>
 	<string name="email_client">E-mailový klient</string>
@@ -184,6 +185,7 @@
 	<string name="registration_view_password_field_hint">Heslo</string>
 	<string name="registration_view_register_button_title">Registrovat se</string>
 	<string name="registration_view_login_button_title">Přihlásit se</string>
+	<string name="register_view_email_already_exists">Uživatel s daným emailem již existuje.</string>
 
 	<!-- SECTION: Users View -->
 	<string name="users_view_toolbar_title">Uživatelé</string>

--- a/ios/DomainLayer/SharedDomain/Package.swift
+++ b/ios/DomainLayer/SharedDomain/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/Matejkob/swift-spyable", from: "0.1.0")
+        .package(url: "https://github.com/Matejkob/swift-spyable", from: "0.1.0"),
+        .package(path: "../Utilities")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -32,6 +33,7 @@ let package = Package(
             name: "SharedDomain",
             dependencies: [
                 "DevstackKmpShared",
+                "Utilities",
                 .product(name: "Spyable", package: "swift-spyable")
             ],
             linkerSettings: [
@@ -42,14 +44,16 @@ let package = Package(
             name: "SharedDomainMocks",
             dependencies: [
                 "SharedDomain",
-                "DevstackKmpShared"
+                "DevstackKmpShared",
+                "Utilities"
             ]
         ),
         .testTarget(
             name: "SharedDomainTests",
             dependencies: [
                 "SharedDomain",
-                "SharedDomainMocks"
+                "SharedDomainMocks",
+                "Utilities"
             ]
         ),
         .binaryTarget(

--- a/ios/DomainLayer/SharedDomain/Sources/SharedDomain/StoreKit/UseCases/RequestFeedbackUseCase.swift
+++ b/ios/DomainLayer/SharedDomain/Sources/SharedDomain/StoreKit/UseCases/RequestFeedbackUseCase.swift
@@ -4,8 +4,10 @@
 //
 
 import Foundation
+import Spyable
 import Utilities
 
+@Spyable
 public protocol RequestFeedbackUseCase {
     func execute() throws
 }
@@ -19,7 +21,7 @@ public struct RequestFeedbackUseCaseImpl: RequestFeedbackUseCase {
     }
     
     public func execute() throws {
-        if Environment.flavor == .debug {
+        if Environment.flavor == Utilities.EnvironmentFlavor.debug {
             guard CommandLine.arguments.contains("-ShouldShowFeedback") else { return }
             
             try storeKitRepository.requestFeedback()

--- a/ios/PresentationLayer/Onboarding/Sources/Onboarding/Errors/ValidationError.swift
+++ b/ios/PresentationLayer/Onboarding/Sources/Onboarding/Errors/ValidationError.swift
@@ -13,11 +13,13 @@ extension ValidationError: LocalizedError {
         switch self {
         case .email(let reason):
             switch reason {
-            case .isEmpty: MR.strings().invalid_email.desc().localized()
+            // TODO: Use MR strings when issue [https://github.com/icerockdev/moko-resources/issues/714] is resolved
+            case .isEmpty: "Invalid email format" // MR.strings().invalid_email.desc().localized()
             }
         case .password(let reason):
             switch reason {
-            case .isEmpty: MR.strings().invalid_password.desc().localized()
+            // TODO: Use MR strings when issue [https://github.com/icerockdev/moko-resources/issues/714] is resolved
+            case .isEmpty: "Invalid password" // MR.strings().invalid_password.desc().localized()
             }
         }
     }

--- a/ios/PresentationLayer/Onboarding/Sources/Onboarding/Errors/ValidationError.swift
+++ b/ios/PresentationLayer/Onboarding/Sources/Onboarding/Errors/ValidationError.swift
@@ -13,12 +13,12 @@ extension ValidationError: LocalizedError {
         switch self {
         case .email(let reason):
             switch reason {
-            // TODO: Use MR strings when issue [https://github.com/icerockdev/moko-resources/issues/714] is resolved
+            #warning("TODO: Use MR strings when issue [https://github.com/icerockdev/moko-resources/issues/714] is resolved")
             case .isEmpty: "Invalid email format" // MR.strings().invalid_email.desc().localized()
             }
         case .password(let reason):
             switch reason {
-            // TODO: Use MR strings when issue [https://github.com/icerockdev/moko-resources/issues/714] is resolved
+            #warning("TODO: Use MR strings when issue [https://github.com/icerockdev/moko-resources/issues/714] is resolved")
             case .isEmpty: "Invalid password" // MR.strings().invalid_password.desc().localized()
             }
         }

--- a/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/LoginViewModelTests.swift
+++ b/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/LoginViewModelTests.swift
@@ -4,6 +4,7 @@
 //
 
 import DependencyInjection
+import DevstackKmpShared
 import Factory
 @testable import Onboarding
 @testable import SharedDomain
@@ -100,7 +101,11 @@ final class LoginViewModelTests: XCTestCase {
     
     func testLoginInvalidPassword() async {
         let vm = createViewModel()
-        loginUseCase.executeThrowableError = AuthError.login(.invalidCredentials)
+        let errorResult = AuthError.InvalidLoginCredentials(throwable: nil)
+        loginUseCase.executeThrowableError = KmmLocalizedError(
+            errorResult: errorResult,
+            localizedMessage: errorResult.localizedMessage(nil)
+        )
         
         vm.onIntent(.changeEmail(LoginData.stubValid.email))
         vm.onIntent(.changePassword(LoginData.stubValid.password))

--- a/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/LoginViewModelTests.swift
+++ b/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/LoginViewModelTests.swift
@@ -104,7 +104,8 @@ final class LoginViewModelTests: XCTestCase {
         let errorResult = AuthError.InvalidLoginCredentials(throwable: nil)
         loginUseCase.executeThrowableError = KmmLocalizedError(
             errorResult: errorResult,
-            localizedMessage: errorResult.localizedMessage(nil)
+            // TODO: Use localizedMessage when issue [https://github.com/icerockdev/moko-resources/issues/714] is resolved
+            localizedMessage: "" // errorResult.localizedMessage(nil)
         )
         
         vm.onIntent(.changeEmail(LoginData.stubValid.email))

--- a/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/LoginViewModelTests.swift
+++ b/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/LoginViewModelTests.swift
@@ -102,9 +102,9 @@ final class LoginViewModelTests: XCTestCase {
     func testLoginInvalidPassword() async {
         let vm = createViewModel()
         let errorResult = AuthError.InvalidLoginCredentials(throwable: nil)
+        #warning("TODO: Use localizedMessage when issue [https://github.com/icerockdev/moko-resources/issues/714] is resolved")
         loginUseCase.executeThrowableError = KmmLocalizedError(
             errorResult: errorResult,
-            // TODO: Use localizedMessage when issue [https://github.com/icerockdev/moko-resources/issues/714] is resolved
             localizedMessage: "" // errorResult.localizedMessage(nil)
         )
         

--- a/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/RegistrationViewModelTests.swift
+++ b/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/RegistrationViewModelTests.swift
@@ -39,7 +39,7 @@ final class RegistrationViewModelTests: XCTestCase {
         await vm.awaitAllTasks()
         
         XCTAssert(!vm.state.isLoading)
-        // TODO: Use MR strings when issue [https://github.com/icerockdev/moko-resources/issues/714] is resolved
+        #warning("TODO: Use MR strings when issue [https://github.com/icerockdev/moko-resources/issues/714] is resolved")
         // XCTAssertEqual(vm.state.alert, AlertData(title: MR.strings().invalid_email.desc().localized()))
         XCTAssertEqual(vm.state.alert, AlertData(title: "Invalid email format"))
         XCTAssertEqual(fc.handleFlowValue, nil)
@@ -56,7 +56,7 @@ final class RegistrationViewModelTests: XCTestCase {
         await vm.awaitAllTasks()
         
         XCTAssert(!vm.state.isLoading)
-        // TODO: Use MR strings when issue [https://github.com/icerockdev/moko-resources/issues/714] is resolved
+        #warning("TODO: Use MR strings when issue [https://github.com/icerockdev/moko-resources/issues/714] is resolved")
         // XCTAssertEqual(vm.state.alert, AlertData(title: MR.strings().invalid_password.desc().localized()))
         XCTAssertEqual(vm.state.alert, AlertData(title: "Invalid password"))
         XCTAssertEqual(fc.handleFlowValue, nil)

--- a/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/RegistrationViewModelTests.swift
+++ b/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/RegistrationViewModelTests.swift
@@ -4,6 +4,7 @@
 //
 
 import DependencyInjection
+import DevstackKmpShared
 import Factory
 @testable import Onboarding
 @testable import SharedDomain
@@ -38,7 +39,7 @@ final class RegistrationViewModelTests: XCTestCase {
         await vm.awaitAllTasks()
         
         XCTAssert(!vm.state.isLoading)
-        XCTAssertEqual(vm.state.alert, AlertData(title: L10n.invalid_email))
+        XCTAssertEqual(vm.state.alert, AlertData(title: MR.strings().invalid_email.desc().localized()))
         XCTAssertEqual(fc.handleFlowValue, nil)
         XCTAssert(registrationUseCase.executeReceivedInvocations == [.stubEmptyEmail])
     }
@@ -53,7 +54,7 @@ final class RegistrationViewModelTests: XCTestCase {
         await vm.awaitAllTasks()
         
         XCTAssert(!vm.state.isLoading)
-        XCTAssertEqual(vm.state.alert, AlertData(title: L10n.invalid_password))
+        XCTAssertEqual(vm.state.alert, AlertData(title: MR.strings().invalid_password.desc().localized()))
         XCTAssertEqual(fc.handleFlowValue, nil)
         XCTAssert(registrationUseCase.executeReceivedInvocations == [.stubEmptyPassword])
     }

--- a/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/RegistrationViewModelTests.swift
+++ b/ios/PresentationLayer/Onboarding/Tests/OnboardingTests/RegistrationViewModelTests.swift
@@ -39,7 +39,9 @@ final class RegistrationViewModelTests: XCTestCase {
         await vm.awaitAllTasks()
         
         XCTAssert(!vm.state.isLoading)
-        XCTAssertEqual(vm.state.alert, AlertData(title: MR.strings().invalid_email.desc().localized()))
+        // TODO: Use MR strings when issue [https://github.com/icerockdev/moko-resources/issues/714] is resolved
+        // XCTAssertEqual(vm.state.alert, AlertData(title: MR.strings().invalid_email.desc().localized()))
+        XCTAssertEqual(vm.state.alert, AlertData(title: "Invalid email format"))
         XCTAssertEqual(fc.handleFlowValue, nil)
         XCTAssert(registrationUseCase.executeReceivedInvocations == [.stubEmptyEmail])
     }
@@ -54,7 +56,9 @@ final class RegistrationViewModelTests: XCTestCase {
         await vm.awaitAllTasks()
         
         XCTAssert(!vm.state.isLoading)
-        XCTAssertEqual(vm.state.alert, AlertData(title: MR.strings().invalid_password.desc().localized()))
+        // TODO: Use MR strings when issue [https://github.com/icerockdev/moko-resources/issues/714] is resolved
+        // XCTAssertEqual(vm.state.alert, AlertData(title: MR.strings().invalid_password.desc().localized()))
+        XCTAssertEqual(vm.state.alert, AlertData(title: "Invalid password"))
         XCTAssertEqual(fc.handleFlowValue, nil)
         XCTAssert(registrationUseCase.executeReceivedInvocations == [.stubEmptyPassword])
     }


### PR DESCRIPTION
# :pencil: Description
- Use error messages from Moko strings in tests

# :bulb: What’s new?
- Using MR strings in tests

# :no_mouth: What’s missing?
- Running tests on CI


