### PR TITLE
[iOS] Define MinimumOSVersion in KMP xcframework

### DIFF
--- a/build-logic/convention/src/main/kotlin/plugin/KmmLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/plugin/KmmLibraryConventionPlugin.kt
@@ -102,6 +102,13 @@ class KmmLibraryConventionPlugin : Plugin<Project> {
                 configureTests()
             }
 
+            // There is a bug in Xcode 15.3 - archive validation fails if SDKs support a lower minimum OS version than the app 
+            // Konan plugin sets minVersion.ios to 12.0 by default, but we have 15.0 in our app
+            // This line changes Konan property to 15.0
+            tasks.withType<KotlinNativeLink> {
+                kotlinOptions.freeCompilerArgs += "-Xoverride-konan-properties=minVersion.ios=15.0"
+            }
+
             tasks.register("buildXCFramework") {
                 dependsOn("assemble${ProjectConstants.iosShared}XCFramework")
             }

--- a/build-logic/convention/src/main/kotlin/plugin/KmmLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/plugin/KmmLibraryConventionPlugin.kt
@@ -18,7 +18,9 @@ import org.gradle.kotlin.dsl.creating
 import org.gradle.kotlin.dsl.getValue
 import org.gradle.kotlin.dsl.getting
 import org.gradle.kotlin.dsl.invoke
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 
 @Suppress("unused")
 class KmmLibraryConventionPlugin : Plugin<Project> {

--- a/ios/CI/FastlaneRunner/Sources/FastlaneRunner/Lanes/Build.swift
+++ b/ios/CI/FastlaneRunner/Sources/FastlaneRunner/Lanes/Build.swift
@@ -25,6 +25,13 @@ extension Fastfile {
         apiKey: AppStoreConnectAPIKey,
         keychain: KeychainConfiguration
     ) {
+        // Temporary until 15.3 or higher is default on CI
+        xcodes(
+            version: "15.3",
+            selectForCurrentBuildOnly: true,
+            binaryPath: "/usr/local/bin/xcodes"
+        )
+        
         if FileManager.default.fileExists(atPath: (keychain.path as NSString).expandingTildeInPath) {
             deleteKeychain(name: .userDefined(keychain.name))
         }


### PR DESCRIPTION
# :pencil: Description
- This PR ensures that builds on CI under Xcode 15.3 work again ⚙️ 

# :bulb: What’s new?
- There is a bug in Xcode 15.3 - archive validation fails if SDKs support a lower minimum OS version than the app. Konan plugin sets `minVersion.ios` to 12.0 by default, but we have 15.0 in our app. Therefore, we have to set it manually to 15.0 for now.

# :no_mouth: What’s missing?
- Nothing

# :books: References
- https://stackoverflow.com/questions/77559967/kotlin-multiplatform-library-info-plist-invalid-minimumosversion
