### PR TITLE
[iOS] ✨ Add automatic simulator detection for KMM

### DIFF
--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack.xcscheme
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Build KMP"
-               scriptText = "if [ -z &quot;$CI&quot; ]; then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    scripts/build-kmp.sh &quot;${CONFIGURATION}&quot; false true true&#10;fi&#10;">
+               scriptText = "if [ -z &quot;$CI&quot; ]; then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    scripts/build-kmp.sh &quot;${CONFIGURATION}&quot; false&#10;fi&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Alpha.xcscheme
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Build KMP"
-               scriptText = "if [ -z &quot;$CI&quot; ]; then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    scripts/build-kmp.sh &quot;${CONFIGURATION}&quot; false true true&#10;fi&#10;">
+               scriptText = "if [ -z &quot;$CI&quot; ]; then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    scripts/build-kmp.sh &quot;${CONFIGURATION}&quot; false&#10;fi&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta.xcscheme
+++ b/ios/DevStack.xcodeproj/xcshareddata/xcschemes/DevStack_Beta.xcscheme
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Build KMP"
-               scriptText = "if [ -z &quot;$CI&quot; ]; then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    scripts/build-kmp.sh &quot;${CONFIGURATION}&quot; false true true&#10;fi&#10;">
+               scriptText = "if [ -z &quot;$CI&quot; ]; then&#10;    cd &quot;${PROJECT_DIR}&quot;&#10;    scripts/build-kmp.sh &quot;${CONFIGURATION}&quot; false&#10;fi&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/scripts/build-kmp.sh
+++ b/ios/scripts/build-kmp.sh
@@ -1,15 +1,21 @@
 #!/bin/zsh -l
 
+set -e
+
 #
 # First argument  - XCODE_CONFIGURATION: debug / release
 # Second argument - X86: true / false
 # Third argument  - ARM64: true / false
 # Fourth argument - ARM64SIM: true / false
 #
+# The last two arguments can be emitted while building with XCode. It is automatically detected
+# whether the destination is a simulator or not.
+#
 # Example:
 # ./scripts/build-kmp.sh debug false true true      -> debug configuration with arm64 + arm64sim architectures (local builds) - default
 # ./scripts/build-kmp.sh debug true false false     -> debug configuration with x86 architecture (tests on Intel based CI)
 # ./scripts/build-kmp.sh release false true false   -> release configuration with arm64 architecture (TestFlight/AppStore builds)
+# ./scripts/build-kmp.sh release false              -> release configuration without x86 architecture and simulator or arm detected automatically
 #
 
 # This ensures that relative paths are correct no matter where the script is executed
@@ -18,8 +24,26 @@ cd "$(dirname "$0")"
 # Read input arguments
 configuration=${1:-debug}
 x86=${2:-false}
-arm64=${3:-true}
-arm64sim=${4:-true}
+arm64=$3
+arm64sim=$4
+
+# Check if arm64 argument is blank
+if [ -z "$arm64" ]; then
+  if [ -z "$__IS_NOT_SIMULATOR" ] || [ "$__IS_NOT_SIMULATOR" = "YES" ]; then
+    arm64=true
+  else
+    arm64=false
+  fi
+fi
+
+# Check if arm64sim argument is blank
+if [ -z "$arm64sim" ]; then
+  if [ -z "$__IS_NOT_SIMULATOR" ] || [ "$__IS_NOT_SIMULATOR" = "NO" ]; then
+    arm64sim=true
+  else
+    arm64sim=false
+  fi
+fi
 
 # Build and copy XCFramework
 cd ../..


### PR DESCRIPTION
# :pencil: Description
Adds automatic detection of simulator build targets to KMM build. This will speed up the build process by not building for unused targets.

# :bulb: What’s new?
- When building via XCode, the last two arguments of the build-kmp.sh script are optional and will be set according to the users selected build target.

# :no_mouth: What’s missing?
- Nothing

# :books: References
- https://stackoverflow.com/questions/74490765/how-to-check-type-of-device-device-simulator-on-run-script-phase-in-build-sett
