### PR TITLE
Fix iOS build

### DIFF
--- a/ios/DomainLayer/SharedDomain/Sources/SharedDomain/Common/Extensions/SharedUseCase+Extensions.swift
+++ b/ios/DomainLayer/SharedDomain/Sources/SharedDomain/Common/Extensions/SharedUseCase+Extensions.swift
@@ -52,9 +52,21 @@ public extension UseCaseFlowResult {
                         continuation.yield(resultSuccess as! Out)
                     }
                 case let resultError as ResultError<AnyObject>:
-                    continuation.finish(throwing: resultError.error.asError)
+                    let resultError = resultError.error
+                    continuation.finish(
+                        throwing: KmmLocalizedError(
+                            errorResult: resultError,
+                            localizedMessage: resultError.localizedMessage(nil)
+                        )
+                    )
                 default:
-                    continuation.finish(throwing: CommonError.unknownError)
+                    let resultError = CommonError.Unknown()
+                    continuation.finish(
+                        throwing: KmmLocalizedError(
+                            errorResult: resultError,
+                            localizedMessage: resultError.localizedMessage(nil)
+                        )
+                    )
                 }
             } onComplete: {
                 continuation.finish()

--- a/shared/src/commonMain/kotlin/kmp/shared/base/error/ErrorMessageProvider.kt
+++ b/shared/src/commonMain/kotlin/kmp/shared/base/error/ErrorMessageProvider.kt
@@ -47,6 +47,7 @@ abstract class ErrorMessageProvider {
             when (this) {
                 is CommonError.NoNetworkConnection -> MR.strings.error_no_internet_connection.desc()
                 CommonError.NoUserLoggedIn -> MR.strings.no_user_logged_in.desc()
+                CommonError.Unknown -> MR.strings.unknown_error.desc()
             }
 }
 

--- a/shared/src/commonMain/kotlin/kmp/shared/base/error/domain/CommonError.kt
+++ b/shared/src/commonMain/kotlin/kmp/shared/base/error/domain/CommonError.kt
@@ -9,4 +9,5 @@ import kmp.shared.base.ErrorResult
 sealed class CommonError(throwable: Throwable? = null) : ErrorResult(throwable = throwable) {
     class NoNetworkConnection(t: Throwable?) : CommonError(t)
     object NoUserLoggedIn : CommonError()
+    object Unknown: CommonError()
 }

--- a/shared/src/commonMain/kotlin/kmp/shared/base/error/domain/CommonError.kt
+++ b/shared/src/commonMain/kotlin/kmp/shared/base/error/domain/CommonError.kt
@@ -9,5 +9,5 @@ import kmp.shared.base.ErrorResult
 sealed class CommonError(throwable: Throwable? = null) : ErrorResult(throwable = throwable) {
     class NoNetworkConnection(t: Throwable?) : CommonError(t)
     object NoUserLoggedIn : CommonError()
-    object Unknown: CommonError()
+    object Unknown : CommonError()
 }


### PR DESCRIPTION
# :pencil: Description
- Fixed iOS build where were deprecated casting KMP errors to Swift errors + missing error

# :bulb: What’s new?
- Unkown error for CommonErrors

# :no_mouth: What’s missing?

# :books: References
